### PR TITLE
Fix/lists

### DIFF
--- a/client/js/index.js
+++ b/client/js/index.js
@@ -1,1 +1,0 @@
-require('details-summary')

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "accessible-autocomplete": "2.0.1",
     "bcrypt": "^5.0.0",
     "classlist-polyfill": "1.2.0",
-    "details-summary": "0.0.1",
     "geojson": "0.5.0",
     "glupe": "1.0.3",
     "good-file": "6.0.1",

--- a/server/views/confirm-location.html
+++ b/server/views/confirm-location.html
@@ -29,21 +29,21 @@
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
-            How to draw a shape
-            </span>
+                How to draw a shape
+              </span>
             </summary>
             <div class="govuk-details__text">
-              <ul class="govuk-list govuk-list--bullet">
-                <li>select 'draw shape'</li>
-                <li>select any point on the site boundary</li>
-                <li>select a second point on the boundary - you should see a line drawn between the first two points </li>
-                <li>keep adding points until the boundary is defined</li>
-                <li>double click or tap when you mark your final point</li>
-                <li>edit the finished shape by dragging the points</li>
-                <li>add more points to a shape by clicking or tapping on a line</li>
-              </ul>
+              <ol class="govuk-list govuk-list--number">
+                <li>Select 'draw shape'.</li>
+                <li>Select any point on the site boundary.</li>
+                <li>Select a second point on the boundary - you should see a line drawn between the first two points.</li>
+                <li>Keep adding points until the boundary is defined.</li>
+                <li>Double click or tap when you mark your final point.</li>
+                <li>Edit the finished shape by dragging the points.</li>
+                <li>Add more points to a shape by clicking or tapping on a line.</li>
+              </ol>
             </div>
-          </details>      
+          </details>
 
           <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/server/views/home.html
+++ b/server/views/home.html
@@ -53,9 +53,11 @@
             </span>
           </summary>
           <div class="govuk-details__text">
-            For help getting flood risk data, contact the Environment Agency.<br/>
-            Telephone: 03708 506 506<br/>
-           Monday to Friday, 8am to 6pm
+            <ul class="govuk-list">
+              <li>For help getting flood risk data, contact the Environment Agency.</li>
+              <li>Telephone: 03708 506 506.</li>
+              <li>Monday to Friday, 8am to 6pm.</li>
+            </ul>
           </div>
         </details>
       </div>


### PR DESCRIPTION
Fixes associated with:
- lists element corrections
- faulty detail element behaviour

FCRM-2391 [https://eaflood.atlassian.net/browse/FCRM-2391](url): Confirm your location: 'How to draw a shape' list could be ordered

FCRM-2387 [https://eaflood.atlassian.net/browse/FCRM-2387](url): Start Page: 'I need help doing things online' details not set out as a list 

FCRM-2390 [https://eaflood.atlassian.net/browse/FCRM-2390](url): Confirm your location: 'How to draw a shape' details dropdown broken on Edge