### PR TITLE
FCRM-4245 corrected no-polygon redirect issue when NGR or eastings are searched

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fmfp",
-  "version": "2.6.0-pre.9",
+  "version": "2.6.0-pre.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fmfp",
-      "version": "2.6.0-pre.9",
+      "version": "2.6.0-pre.10",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmfp",
-  "version": "2.6.0-pre.9",
+  "version": "2.6.0-pre.10",
   "dataVersion": "2.5.1",
   "description": "Flood map for planning",
   "main": "index.js",


### PR DESCRIPTION
One of these files had CRLF line endings rather than LF, so it looks like every line has changed, I suggest hiding whitespace diffs when reviewing