### PR TITLE
FCRM-5310 unit tests run locally using the .env-example variables

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const lab = (exports.lab = Lab.script())
 const Code = require('@hapi/code')
 const { toBool } = require('../config/toBool')
-require('dotenv').config()
 
 lab.experiment('Ensure config is correct', () => {
   lab.test('test config', () => {

--- a/test/routes/404.js
+++ b/test/routes/404.js
@@ -1,9 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
+
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('404', () => {
   let server

--- a/test/routes/about.js
+++ b/test/routes/about.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { JSDOM } = require('jsdom')
 const externalHealthCheck = require('../../server/services/external-health-check')
-require('dotenv').config()
 
 lab.experiment('About Page', () => {
   const options = { method: 'GET', url: '/about' }

--- a/test/routes/check-your-details.js
+++ b/test/routes/check-your-details.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -8,7 +9,6 @@ const { payloadMatchTest } = require('../utils')
 const sinon = require('sinon')
 const ApplicationReviewSummaryViewModel = require('../../server/models/check-your-details')
 const addressService = require('../../server/services/address')
-require('dotenv').config()
 
 lab.experiment('check-your-details', () => {
   let server

--- a/test/routes/confirm-location.js
+++ b/test/routes/confirm-location.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -5,7 +6,6 @@ const headers = require('../models/page-headers')
 const isEnglandService = require('../../server/services/is-england')
 const createServer = require('../../server')
 const { JSDOM } = require('jsdom')
-require('dotenv').config()
 
 lab.experiment('confirm-location', () => {
   let server

--- a/test/routes/confirmation.js
+++ b/test/routes/confirmation.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
 const { JSDOM } = require('jsdom')
-require('dotenv').config()
 
 lab.experiment('confirmation', () => {
   let server

--- a/test/routes/contact.js
+++ b/test/routes/contact.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { payloadMatchTest, titleTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('contact', () => {
   let server

--- a/test/routes/cookies.js
+++ b/test/routes/cookies.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
-require('dotenv').config()
 
 lab.experiment('cookies', () => {
   let server

--- a/test/routes/england-only.js
+++ b/test/routes/england-only.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const headers = require('../models/page-headers')
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('england-only', () => {
   let server

--- a/test/routes/flood-zone-results-explained.js
+++ b/test/routes/flood-zone-results-explained.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { JSDOM } = require('jsdom')
-require('dotenv').config()
 
 lab.experiment('flood-zone-results-explained', () => {
   let server

--- a/test/routes/flood-zone-results.js
+++ b/test/routes/flood-zone-results.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -8,7 +9,6 @@ const FloodRiskView = require('../../server/models/flood-risk-view')
 const sinon = require('sinon')
 const { JSDOM } = require('jsdom')
 const zeroAreaPolygons = require('../services/zeroAreaPolygons')
-require('dotenv').config()
 
 lab.experiment('flood-zone-results', () => {
   let server

--- a/test/routes/home.js
+++ b/test/routes/home.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -5,7 +6,6 @@ const headers = require('../models/page-headers')
 const addressService = require('../../server/services/address')
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('home', () => {
   let server

--- a/test/routes/location.js
+++ b/test/routes/location.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -6,7 +7,6 @@ const addressService = require('../../server/services/address')
 const isValidNgrService = require('../../server/services/is-valid-ngr')
 const createServer = require('../../server')
 const { payloadMatchTest, titleTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('location', () => {
   let server

--- a/test/routes/maintenance.js
+++ b/test/routes/maintenance.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('maintenance', () => {
   let server

--- a/test/routes/order-not-submitted.js
+++ b/test/routes/order-not-submitted.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
-require('dotenv').config()
 
 lab.experiment('order-not-submitted', () => {
   let server

--- a/test/routes/os-terms.js
+++ b/test/routes/os-terms.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
-require('dotenv').config()
 
 lab.experiment('os-terms', () => {
   let server

--- a/test/routes/pdf.js
+++ b/test/routes/pdf.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -5,7 +6,6 @@ const createServer = require('../../server')
 const riskService = require('../../server/services/risk')
 const Wreck = require('@hapi/wreck')
 const { config } = require('../../config')
-require('dotenv').config()
 
 lab.experiment('PDF', () => {
   let server

--- a/test/routes/privacy-notice.js
+++ b/test/routes/privacy-notice.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('privacy-notice', () => {
   let server

--- a/test/routes/robots.js
+++ b/test/routes/robots.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
-require('dotenv').config()
 
 lab.experiment('robots.txt', () => {
   let server

--- a/test/routes/terms-conditions.js
+++ b/test/routes/terms-conditions.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const createServer = require('../../server')
 const { payloadMatchTest } = require('../utils')
-require('dotenv').config()
 
 lab.experiment('terms-and-conditions', () => {
   let server

--- a/test/services/address.js
+++ b/test/services/address.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const { findByPlace, getPostcodeFromEastingorNorthing } = require('../../server/services/address')
 const util = require('../../server/util')
 const { config } = require('../../config')
-require('dotenv').config()
 
 lab.experiment('address', () => {
   let restoreGetJson

--- a/test/services/is-england.js
+++ b/test/services/is-england.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const isEnglandService = require('../../server/services/is-england')
 const util = require('../../server/util')
 const createServer = require('../../server')
-require('dotenv').config()
 
 lab.experiment('is-england', () => {
   let server

--- a/test/services/is-valid-easting-northing.js
+++ b/test/services/is-valid-easting-northing.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const isValidEastingService = require('../../server/services/is-valid-easting')
 const isValidNorthingService = require('../../server/services/is-valid-northing')
 const isValidEastingNorthingService = require('../../server/services/is-valid-easting-northing')
-require('dotenv').config()
 
 lab.experiment('is-valid-easting-northing', () => {
   let restoreIsValidEastingService

--- a/test/services/is-valid-easting.js
+++ b/test/services/is-valid-easting.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const isValidEastingService = require('../../server/services/is-valid-easting')
-require('dotenv').config()
 
 lab.experiment('is-valid-easting', () => {
   lab.test('isValidEastingService.get should be valid if easting is between 1 and 700,000', async () => {

--- a/test/services/is-valid-ngr.js
+++ b/test/services/is-valid-ngr.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const isValidNgrService = require('../../server/services/is-valid-ngr')
-require('dotenv').config()
 
 lab.experiment('is-valid-ngr', () => {
   lab.test('isValidNgrService.get should be valid if ngr of length 12 is valid', async () => {

--- a/test/services/is-valid-northing.js
+++ b/test/services/is-valid-northing.js
@@ -1,8 +1,8 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const isValidNorthingService = require('../../server/services/is-valid-northing')
-require('dotenv').config()
 
 lab.experiment('is-valid-northing', () => {
   lab.test('isValidNorthingService.get should be valid if northing is between 1 and 1,300,000', async () => {

--- a/test/services/ngr-to-bng.js
+++ b/test/services/ngr-to-bng.js
@@ -1,9 +1,9 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-require('dotenv').config()
 
 lab.experiment('ngr-to-bng', () => {
   let stubNgrToBng

--- a/test/services/pso-contact.js
+++ b/test/services/pso-contact.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const { method: getPsoContacts } = require('../../server/services/pso-contact')
 const { config } = require('../../config')
 const util = require('../../server/util')
-require('dotenv').config()
 
 lab.experiment('pso-contact', () => {
   let restoreUtilGetJson

--- a/test/services/punctuateAreaName.js
+++ b/test/services/punctuateAreaName.js
@@ -1,7 +1,7 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
-require('dotenv').config()
 
 const { punctuateAreaName } = require('../../server/services/punctuateAreaName')
 

--- a/test/services/risk.js
+++ b/test/services/risk.js
@@ -1,10 +1,10 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
 const { getByPolygon } = require('../../server/services/risk')
 const util = require('../../server/util')
 const { config } = require('../../config')
-require('dotenv').config()
 
 lab.experiment('risk', () => {
   let restoreGetJson

--- a/test/services/shape-utils.js
+++ b/test/services/shape-utils.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const lab = (exports.lab = Lab.script())
@@ -9,7 +10,6 @@ const {
   polygonStartEnd
 } = require('../../server/services/shape-utils')
 const zeroAreaPolygons = require('./zeroAreaPolygons')
-require('dotenv').config()
 
 lab.experiment('shape-utils - polygonToArray', () => {
   lab.test('polygonToArray should return an array for polygon strings "[[0,0],[0,10],[10,10],[10,0]]"', async () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Code = require('@hapi/code')
-require('dotenv').config()
 
 module.exports = {
   payloadMatchTest: async (payload, regex, expectedMatchCount = 1) => {

--- a/test/views/helpers/json.js
+++ b/test/views/helpers/json.js
@@ -1,7 +1,7 @@
+require('dotenv').config({ path: 'config/.env-example' })
 const Lab = require('@hapi/lab')
 const lab = (exports.lab = Lab.script())
 const Code = require('@hapi/code')
-require('dotenv').config()
 
 const jsonHelper = require('../../../server/views/helpers/json')
 


### PR DESCRIPTION
Just so we don't get any suprises when we push, I've configured the unit tests so they use the same env variables locally as they do on github.

I hoisted all of the config imports to the top of each file, as they must be run prior to createServer. I found that although all tests would pass, when they werre ALL run, some would fail when they were run individually (due to the order of the imports).