### PR TITLE
FMFP-5675 - adding in security headers to requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,8 @@ async function createServer () {
         options: {
           abortEarly: false
         }
-      }
+      },
+      security: true
     },
     cache: [
       {

--- a/server/views/location.html
+++ b/server/views/location.html
@@ -21,7 +21,7 @@
               errorList: errorSummary
             }) 
           }}
-          <div class="hide" data-journey="{{analyticsPageEvent | safe}}"></div>
+          <div class="hide" data-journey="{{ analyticsPageEvent }}"></div>
         {% endif %}
 
         {% set placeOrPostcodeHtml %}


### PR DESCRIPTION
Added in `security: true` for request options
This includes several headers such as:

- Referrer Policy: strict-origin-when-cross-origin
- X-Frame-Options: DENY
- X-Xss-Protection: 1;mode=block
- X-Content-Type-Options: nosniff

As well as removing `| safe` from the google anaytics error event, to prevent XSS vulnerability