### PR TITLE
Remove 'allowProduct1' config

### DIFF
--- a/config/__tests__/config.spec.js
+++ b/config/__tests__/config.spec.js
@@ -19,7 +19,6 @@ describe('Ensure config is correct', () => {
       appType: 'internal',
       server: { port: '8050' },
       views: { isCached: false },
-      allowProduct1: true, // This covers when the value is NOT in the config, defaults true
       analyticsAccount: 'replace_this',
       googleVerification: 'replace_this',
       fbAppId: 'replace_this',
@@ -76,14 +75,12 @@ describe('Ensure config is correct', () => {
     jest.resetModules()
     process.env.ENV = 'prod'
     process.env.agolRofrsDepthOrExtents = 'Extents'
-    process.env.allowProduct1 = 'false'
     const { config } = require('../index')
     const expectedConfig = {
       env: 'prod',
       appType: 'internal',
       server: { port: '8050' },
       views: { isCached: false },
-      allowProduct1: false, // This covers when the value is in the config and set to 'false'
       analyticsAccount: 'replace_this',
       googleVerification: 'replace_this',
       fbAppId: 'replace_this',

--- a/config/index.js
+++ b/config/index.js
@@ -48,7 +48,6 @@ const config = {
   views: {
     isCached: toBool(process.env.viewsIsCached)
   },
-  allowProduct1: !(process.env.allowProduct1 === 'false'),
   analyticsAccount: process.env.analyticsAccount,
   googleVerification: process.env.googleVerification,
   fbAppId: process.env.fbAppId,

--- a/config/schema.js
+++ b/config/schema.js
@@ -14,7 +14,6 @@ const schema = Joi.object({
   views: Joi.object().required().keys({
     isCached: Joi.boolean().strict().required()
   }),
-  allowProduct1: Joi.boolean().strict().required(),
   analyticsAccount: Joi.string().required().allow(''),
   googleVerification: Joi.string().required().allow(''),
   fbAppId: Joi.string().required().allow(''),

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -322,58 +322,56 @@ exports[`next-steps on internal should show the "Order flood risk data" for opte
         Download a flood map for this location
       </h3>
 
-      
-  <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
-    data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Add a reference to the flood map and set the scale
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <form class="form" id="product-1-form" method="POST" action="product-1">
-        <input name="polygon" type="hidden" value="[[9323,1323],[9323,1324],[9324,1324],[9324,1323],[9323,1323]]" />
-        <input name="isRiskAdminArea" type="hidden" value="false" />
-        <input name="floodZone" type="hidden" value="3" />
+      <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
+  data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Add a reference to the flood map and set the scale
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <form class="form" id="product-1-form" method="POST" action="product-1">
+      <input name="polygon" type="hidden" value="[[9323,1323],[9323,1324],[9324,1324],[9324,1323],[9323,1323]]" />
+      <input name="isRiskAdminArea" type="hidden" value="false" />
+      <input name="floodZone" type="hidden" value="3" />
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="reference">
-                Add a reference
-              </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="reference-hint" class="govuk-hint govuk-hint--block">
-                Optional. This is chosen by you to help you find the report
-                later and should be less than 25 characters.
-              </span>
-            </p>
-            <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
-          </div>
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="reference">
+              Add a reference
+            </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="reference-hint" class="govuk-hint govuk-hint--block">
+              Optional. This is chosen by you to help you find the report
+              later and should be less than 25 characters.
+            </span>
+          </p>
+          <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
+        </div>
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="scale"> Scale </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="scale-hint" class="govuk-hint govuk-hint--block">
-                Select the scale of the map shown in the report
-              </span>
-            </p>
-            <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
-              <option value="2500">1:2500</option>
-              <option value="10000">1:10000</option>
-              <option value="25000">1:25000</option>
-              <option value="50000">1:50000</option>
-            </select>
-          </div>
-        </form>
-      </div>
-    </details>
-    <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
-      Download flood map for this location (PDF)
-    </button>
-  
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="scale"> Scale </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="scale-hint" class="govuk-hint govuk-hint--block">
+              Select the scale of the map shown in the report
+            </span>
+          </p>
+          <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
+            <option value="2500">1:2500</option>
+            <option value="10000">1:10000</option>
+            <option value="25000">1:25000</option>
+            <option value="50000">1:50000</option>
+          </select>
+        </div>
+      </form>
+    </div>
+  </details>
+  <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
+    Download flood map for this location (PDF)
+  </button>
 
       <h3 class="govuk-heading-m">
         Order flood risk data for rivers and the sea
@@ -879,58 +877,56 @@ exports[`next-steps on public should show the "Order flood risk data" for opted 
         Download a flood map for this location
       </h3>
 
-      
-  <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
-    data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Add a reference to the flood map and set the scale
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <form class="form" id="product-1-form" method="POST" action="product-1">
-        <input name="polygon" type="hidden" value="[[9323,1323],[9323,1324],[9324,1324],[9324,1323],[9323,1323]]" />
-        <input name="isRiskAdminArea" type="hidden" value="false" />
-        <input name="floodZone" type="hidden" value="3" />
+      <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
+  data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Add a reference to the flood map and set the scale
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <form class="form" id="product-1-form" method="POST" action="product-1">
+      <input name="polygon" type="hidden" value="[[9323,1323],[9323,1324],[9324,1324],[9324,1323],[9323,1323]]" />
+      <input name="isRiskAdminArea" type="hidden" value="false" />
+      <input name="floodZone" type="hidden" value="3" />
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="reference">
-                Add a reference
-              </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="reference-hint" class="govuk-hint govuk-hint--block">
-                Optional. This is chosen by you to help you find the report
-                later and should be less than 25 characters.
-              </span>
-            </p>
-            <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
-          </div>
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="reference">
+              Add a reference
+            </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="reference-hint" class="govuk-hint govuk-hint--block">
+              Optional. This is chosen by you to help you find the report
+              later and should be less than 25 characters.
+            </span>
+          </p>
+          <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
+        </div>
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="scale"> Scale </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="scale-hint" class="govuk-hint govuk-hint--block">
-                Select the scale of the map shown in the report
-              </span>
-            </p>
-            <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
-              <option value="2500">1:2500</option>
-              <option value="10000">1:10000</option>
-              <option value="25000">1:25000</option>
-              <option value="50000">1:50000</option>
-            </select>
-          </div>
-        </form>
-      </div>
-    </details>
-    <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
-      Download flood map for this location (PDF)
-    </button>
-  
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="scale"> Scale </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="scale-hint" class="govuk-hint govuk-hint--block">
+              Select the scale of the map shown in the report
+            </span>
+          </p>
+          <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
+            <option value="2500">1:2500</option>
+            <option value="10000">1:10000</option>
+            <option value="25000">1:25000</option>
+            <option value="50000">1:50000</option>
+          </select>
+        </div>
+      </form>
+    </div>
+  </details>
+  <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
+    Download flood map for this location (PDF)
+  </button>
 
       <h3 class="govuk-heading-m">
         Order flood risk data for rivers and the sea

--- a/server/routes/next-steps.js
+++ b/server/routes/next-steps.js
@@ -19,10 +19,9 @@ module.exports = [
         )
 
         const showOrderProduct4Button = config.appType === 'internal' || contactData.useAutomatedService === true
-        const showProduct1Button = config.allowProduct1
         floodData.centreOfPolygon = getCentreOfPolygon(polygon)
         floodData.isRiskAdminArea = isRiskAdmin
-        return h.view('next-steps', { polygon, floodData, contactData, showOrderProduct4Button, showProduct1Button })
+        return h.view('next-steps', { polygon, floodData, contactData, showOrderProduct4Button })
       }
     }
   }

--- a/server/routes/results.js
+++ b/server/routes/results.js
@@ -17,13 +17,12 @@ module.exports = [
           request.server.methods.getFloodDataByPolygon(polygon)]
         )
         const showOrderProduct4Button = config.appType === 'internal' || contactData.useAutomatedService === true
-        const showProduct1Button = config.allowProduct1
         floodData.areaInHectares = getAreaInHectares(polygon)
         floodData.centreOfPolygon = getCentreOfPolygon(polygon)
         floodData.isFZ1Andlt1ha = floodData.floodZone === '1' && floodData.areaInHectares < 1
         floodData.isFZ1Andgt1ha = floodData.floodZone === '1' && floodData.areaInHectares >= 1
         floodData.areaInHectares = floodData.areaInHectares !== '0' && floodData.areaInHectares !== 0 ? floodData.areaInHectares : 'less than 0.01'
-        return h.view('results', { polygon, floodData, contactData, showOrderProduct4Button, showProduct1Button })
+        return h.view('results', { polygon, floodData, contactData, showOrderProduct4Button })
       }
     }
   }

--- a/server/views/partials/order-product-one.html
+++ b/server/views/partials/order-product-one.html
@@ -1,60 +1,50 @@
-{% if showProduct1Button %}
-  <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
-    data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Add a reference to the flood map and set the scale
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <form class="form" id="product-1-form" method="POST" action="product-1">
-        <input name="polygon" type="hidden" value="{{ polygon }}" />
-        <input name="isRiskAdminArea" type="hidden" value="{{ floodData.isRiskAdminArea }}" />
-        <input name="floodZone" type="hidden" value="{{ floodData.floodZone }}" />
+<details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details"
+  data-journey-click="Flood-Zone-Results:DETAIL-CLICK:Add-A-Reference">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Add a reference to the flood map and set the scale
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <form class="form" id="product-1-form" method="POST" action="product-1">
+      <input name="polygon" type="hidden" value="{{ polygon }}" />
+      <input name="isRiskAdminArea" type="hidden" value="{{ floodData.isRiskAdminArea }}" />
+      <input name="floodZone" type="hidden" value="{{ floodData.floodZone }}" />
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="reference">
-                Add a reference
-              </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="reference-hint" class="govuk-hint govuk-hint--block">
-                Optional. This is chosen by you to help you find the report
-                later and should be less than 25 characters.
-              </span>
-            </p>
-            <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
-          </div>
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="reference">
+              Add a reference
+            </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="reference-hint" class="govuk-hint govuk-hint--block">
+              Optional. This is chosen by you to help you find the report
+              later and should be less than 25 characters.
+            </span>
+          </p>
+          <input class="govuk-input form-control govuk-input--width-20" id="reference" name="reference" type="text" maxlength="25" aria-describedby="reference-hint" />
+        </div>
 
-          <div class="govuk-form-group">
-            <h3 class="govuk-label-wrapper">
-              <label class="govuk-label--m" for="scale"> Scale </label>
-            </h3>
-            <p class="govuk-body">
-              <span id="scale-hint" class="govuk-hint govuk-hint--block">
-                Select the scale of the map shown in the report
-              </span>
-            </p>
-            <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
-              <option value="2500">1:2500</option>
-              <option value="10000">1:10000</option>
-              <option value="25000">1:25000</option>
-              <option value="50000">1:50000</option>
-            </select>
-          </div>
-        </form>
-      </div>
-    </details>
-    <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
-      Download flood map for this location (PDF)
-    </button>
-  {% else %}
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-visually-hidden">Warning</span>
-          The ability to download the flood map for this location is temporarily unavailable.
-       </strong>
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            <label class="govuk-label--m" for="scale"> Scale </label>
+          </h3>
+          <p class="govuk-body">
+            <span id="scale-hint" class="govuk-hint govuk-hint--block">
+              Select the scale of the map shown in the report
+            </span>
+          </p>
+          <select class="govuk-select" id="scale" name="scale" aria-describedby="scale-hint">
+            <option value="2500">1:2500</option>
+            <option value="10000">1:10000</option>
+            <option value="25000">1:25000</option>
+            <option value="50000">1:50000</option>
+          </select>
+        </div>
+      </form>
     </div>
-  {% endif %}
+  </details>
+  <button href="#" form="product-1-form" id="product-1-button" type="submit" class="govuk-button govuk-button--secondary" draggable="false">
+    Download flood map for this location (PDF)
+  </button>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCRM-6116

During initial implementation ‘product 1’ included a config variable to hide it from the web app. This is no longer required as it should always be visible, so the variable can be removed.