### PR TITLE
Black and white Map style is getting blank on max zoom in level

### DIFF
--- a/server/routes/defra-map/styles/OS_VTS_27700_Black_and_White.json
+++ b/server/routes/defra-map/styles/OS_VTS_27700_Black_and_White.json
@@ -5,7 +5,7 @@
     "sources": {
         "esri": {
             "type": "vector",
-            "url": "https://api.os.uk/maps/vector/v1/vts"
+            "url": "vts-tile.json"
         }
     },
     "layers": [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCRM-6132

While adding an polygon and max zoom in, the Black and white Map style is getting blank.