### PR TITLE
FCRM-6609 - show 'opted out' instead of 'boundary too big'

### DIFF
--- a/client/sass/map/index.scss
+++ b/client/sass/map/index.scss
@@ -146,7 +146,7 @@ body.js-enabled:not([data-fm-error]) {
 .govuk-heading-m,
 .govuk-list>li,
 .govuk-details__text,
-.fm-c-panel, 
+.fm-c-panel,
 .fm-c-panel--edit {
   color: var(--foreground-colour);
 }
@@ -200,6 +200,10 @@ body.js-enabled:not([data-fm-error]) {
 }
 
 // Start of fix of  a Map Component bug (must be fixed there)
+  .fm-o-top__column:first-child:not(:has(.fm-c-search))  {
+     position: static;
+ }
+
 .fm-o-top__column:first-child > .fm-c-panel {
     position: absolute;
     left: 15px;

--- a/server/routes/__tests__/results.spec.js
+++ b/server/routes/__tests__/results.spec.js
@@ -558,6 +558,46 @@ describe('Results page', () => {
         expect(pageContent.adminUpdatedData).toEqual(false)
       })
     })
+
+    it('Should still show the opted out text if boundary is over 300ha', async () => {
+      getPsoContactsByPolygon.mockResolvedValue({
+        isEngland: true,
+        EmailAddress: 'emdenquiries@environment-agency.gov.uk',
+        AreaName: 'East Midlands',
+        useAutomatedService: false,
+        LocalAuthorities: 'Derbyshire Dales'
+      })
+      getFloodDataByPolygon.mockResolvedValue({
+        floodzone_2: false,
+        floodzone_3: true,
+        floodZone: '3',
+        floodZoneLevel: 'high',
+        floodZoneClimateChange: false,
+        floodZoneClimateChangeNoData: false,
+        surfaceWater: {
+          riskBandId: 3,
+          riskBand: 'High',
+          riskBandPercent: '3.3',
+          riskBandOdds: '1 in 30'
+        },
+        isRiskAdminArea: false
+      })
+      getAreaInHectaresSpy.mockReturnValue(350)
+      const response = await submitGetRequest({ url: `${url}?${polygonQuery}` })
+      const pageContent = getElementByIdAndFormat(response.payload)
+      expect(pageContent.heading).toEqual(getHeadingAndMeaningText(3).heading)
+      expect(pageContent.fzMeaningDescription).toEqual(getHeadingAndMeaningText(3).meaning)
+      expect(pageContent.rsBulletPoint).toEqual(rsBulletPointText)
+      expect(pageContent.fraTitle).toEqual(fraTitleText)
+      expect(pageContent.fraRequired).toEqual(fraRequiredText)
+      expect(pageContent.fzProbability).toEqual(getFZProbabilityText(3, 'high'))
+      expect(pageContent.boundaryTooBig).toEqual(false)
+      expect(pageContent.orderP4Button).toEqual(false)
+      expect(pageContent.swSummaryTitle).toEqual(getSWInfoText().swSummaryTitleText)
+      expect(pageContent.swSummaryKeyCC).toEqual(getSWInfoText().swSummaryKeyCCText)
+      expect(pageContent.adminUpdatedData).toEqual(false)
+      expect(pageContent.siteDrawnIsLessThan).toEqual(false)
+    })
   })
 
   describe('On Internal', () => {

--- a/server/views/partials/results-page/order-product-four.html
+++ b/server/views/partials/results-page/order-product-four.html
@@ -13,14 +13,7 @@
       Find out what products are available
     </a>
   </p>
-{% elif over300Hectares %}
-  <p class="govuk-body" id="boundaryTooBig">The boundary is too big to order detailed flood risk information (product 4). Reduce the boundary size to under 300 hectares.</p>
-  <br>
-  <a id="backToMap" href="map?encodedPolygon={{ encodedPolygon }}" class="govuk-button" data-module="govuk-button" data-testid="order-product4">
-    Edit boundary
-  </a>
-  <p>If your boundary needs to be bigger than 300 hectares, contact the Environment Agency team in {{ contactData.AreaName }} at {{ contactData.EmailAddress }}.</p>
-{% else %}
+{% elif not showOrderProduct4Button %}
   <p class="govuk-body" data-testid="order-product4-email">
     To order flood risk data for this site, contact the Environment Agency team in {{ contactData.AreaName }} at
     <a class="govuk-link" href="mailto:{{ contactData.EmailAddress }}">{{ contactData.EmailAddress }}</a>
@@ -43,4 +36,11 @@
       <li>flood defence breach hazard information.</li>
     </ul>
   {% endif %}
+{% elif over300Hectares %}
+  <p class="govuk-body" id="boundaryTooBig">The boundary is too big to order detailed flood risk information (product 4). Reduce the boundary size to under 300 hectares.</p>
+  <br>
+  <a id="backToMap" href="map?encodedPolygon={{ encodedPolygon }}" class="govuk-button" data-module="govuk-button" data-testid="order-product4">
+    Edit boundary
+  </a>
+  <p>If your boundary needs to be bigger than 300 hectares, contact the Environment Agency team in {{ contactData.AreaName }} at {{ contactData.EmailAddress }}.</p>
 {% endif %}


### PR DESCRIPTION


NB also has a further css fix to the previous PR, as that one fixed the search bar but broke the key