### PR TITLE
Align FMfP header with standard GOV.UK service branding

### DIFF
--- a/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
@@ -183,8 +183,6 @@ exports[`accessibility statement Should return accessibility statement page 1`] 
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
@@ -179,19 +179,41 @@ exports[`accessibility statement Should return accessibility statement page 1`] 
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -183,8 +183,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -754,8 +750,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -784,8 +778,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1325,8 +1317,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1355,8 +1345,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1896,8 +1884,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1926,8 +1912,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -2467,8 +2451,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -2497,8 +2479,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -3038,8 +3018,6 @@ exports[`Check your details page GET Should serve contact view with error messag
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -3068,8 +3046,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -790,7 +789,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -1360,7 +1358,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -1924,7 +1921,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -2494,7 +2490,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -3058,7 +3053,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -179,19 +179,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -728,19 +750,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1277,19 +1321,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1826,19 +1892,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -2375,19 +2463,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -2924,19 +3034,41 @@ exports[`Check your details page GET Should serve contact view with error messag
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
@@ -183,8 +183,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, enc
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -659,8 +655,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, pol
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -689,8 +683,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1135,8 +1127,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, enc
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1165,8 +1155,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1614,8 +1602,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, pol
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1644,8 +1630,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
@@ -179,19 +179,41 @@ exports[`confirmation Should return content correctly based on flood zone 1, enc
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -633,19 +655,41 @@ exports[`confirmation Should return content correctly based on flood zone 1, pol
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1087,19 +1131,41 @@ exports[`confirmation Should return content correctly based on flood zone 3, enc
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1544,19 +1610,41 @@ exports[`confirmation Should return content correctly based on flood zone 3, pol
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -695,7 +694,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -1170,7 +1168,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -1642,7 +1639,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -179,19 +179,41 @@ exports[`contact GET Should error if no polygon is present 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -573,19 +595,41 @@ exports[`contact GET Should get contact page if encoded polygon query is present
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1082,19 +1126,41 @@ exports[`contact GET Should get contact page if encoded polygon query is present
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1591,19 +1657,41 @@ exports[`contact GET Should get contact page if polygon query is present, with a
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -2100,19 +2188,41 @@ exports[`contact GET Should get contact page if polygon query is present, with a
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -2609,19 +2719,41 @@ exports[`contact GET Should get contact page with user name and email if cookie 
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -3122,19 +3254,41 @@ exports[`contact GET Should get contact page with user name and email if cookie 
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -3635,19 +3789,41 @@ exports[`contact POST Should return contact view with error message if blank ema
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -4184,19 +4360,41 @@ exports[`contact POST Should return contact view with error message if blank nam
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -4733,19 +4931,41 @@ exports[`contact POST Should return contact view with error message if email con
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -5282,19 +5502,41 @@ exports[`contact POST Should return contact view with error message if fullname 
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -5831,19 +6073,41 @@ exports[`contact POST Should return contact view with error message if invalid e
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -6380,19 +6644,41 @@ exports[`contact POST Should return contact view with error message if name cont
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -183,8 +183,6 @@ exports[`contact GET Should error if no polygon is present 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -599,8 +595,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -629,8 +623,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1130,8 +1122,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1160,8 +1150,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1661,8 +1649,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1691,8 +1677,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -2192,8 +2176,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -2222,8 +2204,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -2723,8 +2703,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -2753,8 +2731,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -3258,8 +3234,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -3288,8 +3262,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -3793,8 +3765,6 @@ exports[`contact POST Should return contact view with error message if blank ema
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -3823,8 +3793,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -4364,8 +4332,6 @@ exports[`contact POST Should return contact view with error message if blank nam
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -4394,8 +4360,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -4935,8 +4899,6 @@ exports[`contact POST Should return contact view with error message if email con
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -4965,8 +4927,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -5506,8 +5466,6 @@ exports[`contact POST Should return contact view with error message if fullname 
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -5536,8 +5494,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -6077,8 +6033,6 @@ exports[`contact POST Should return contact view with error message if invalid e
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -6107,8 +6061,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -6648,8 +6600,6 @@ exports[`contact POST Should return contact view with error message if name cont
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -6678,8 +6628,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -635,7 +634,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -1165,7 +1163,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -1689,7 +1686,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -2219,7 +2215,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -2743,7 +2738,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -3277,7 +3271,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -3805,7 +3798,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -4375,7 +4367,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -4939,7 +4930,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -5509,7 +5499,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -6076,7 +6065,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -6640,7 +6628,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
@@ -183,8 +183,6 @@ exports[`cookies Should return cookies page successfully with cookies accepted o
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -794,8 +790,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected b
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -824,8 +818,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1405,8 +1397,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected o
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1435,8 +1425,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
@@ -179,19 +179,41 @@ exports[`cookies Should return cookies page successfully with cookies accepted o
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -768,19 +790,41 @@ exports[`cookies Should return cookies page successfully with cookies rejected b
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1357,19 +1401,41 @@ exports[`cookies Should return cookies page successfully with cookies rejected o
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -833,7 +832,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -1437,7 +1435,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
@@ -179,19 +179,41 @@ exports[`England Only Page england-only with no params 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
@@ -183,8 +183,6 @@ exports[`England Only Page england-only with no params 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/error.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/error.spec.js.snap
@@ -183,8 +183,6 @@ exports[`error page Should return error page 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/error.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/error.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/error.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/error.spec.js.snap
@@ -179,19 +179,41 @@ exports[`error page Should return error page 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -631,7 +630,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 
@@ -1042,7 +1040,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -1447,7 +1444,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
@@ -179,19 +179,41 @@ exports[`Feedback Should return feedback page with no userAgent 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -569,19 +591,41 @@ exports[`Feedback Should return feedback page with ref being set as feedback 1`]
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -959,19 +1003,41 @@ exports[`Feedback Should return feedback page with ref being set without feedbac
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -1349,19 +1415,41 @@ exports[`Feedback Should return feedback page with userAgent being set 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
@@ -183,8 +183,6 @@ exports[`Feedback Should return feedback page with no userAgent 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -595,8 +591,6 @@ exports[`Feedback Should return feedback page with ref being set as feedback 1`]
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -625,8 +619,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1007,8 +999,6 @@ exports[`Feedback Should return feedback page with ref being set without feedbac
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1037,8 +1027,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -1419,8 +1407,6 @@ exports[`Feedback Should return feedback page with userAgent being set 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -1449,8 +1435,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/home.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/home.spec.js.snap
@@ -179,19 +179,41 @@ exports[`home route should match snapshot 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/home.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/home.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/home.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/home.spec.js.snap
@@ -183,8 +183,6 @@ exports[`home route should match snapshot 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
@@ -179,19 +179,41 @@ exports[`how-to-use-flood-map-for-planning-data Should return how-to-use-flood-m
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
@@ -183,8 +183,6 @@ exports[`how-to-use-flood-map-for-planning-data Should return how-to-use-flood-m
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -639,7 +638,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
@@ -183,8 +183,6 @@ exports[`maintenance Should get /maintainence successfully 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -603,8 +599,6 @@ exports[`maintenance Should get /maintenance successfully 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -633,8 +627,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
@@ -179,19 +179,41 @@ exports[`maintenance Should get /maintainence successfully 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -577,19 +599,41 @@ exports[`maintenance Should get /maintenance successfully 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
@@ -179,19 +179,41 @@ exports[`map-help Should return map-help page 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
@@ -183,8 +183,6 @@ exports[`map-help Should return map-help page 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -183,8 +183,6 @@ exports[`next-steps on internal should show the "Order flood risk data" for opte
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -760,8 +756,6 @@ exports[`next-steps on public should show the "Order flood risk data" for opted 
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -790,8 +784,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -796,7 +795,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -179,19 +179,41 @@ exports[`next-steps on internal should show the "Order flood risk data" for opte
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -734,19 +756,41 @@ exports[`next-steps on public should show the "Order flood risk data" for opted 
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
@@ -179,19 +179,41 @@ exports[`order-not-submitted Should return 400 error when no polgyon provided 1`
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 
@@ -573,19 +595,41 @@ exports[`order-not-submitted Should return order not submitted when encoded poly
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         
@@ -635,7 +634,6 @@ data-module="govuk-service-navigation"
     </span>
   </p>
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
@@ -183,8 +183,6 @@ exports[`order-not-submitted Should return 400 error when no polgyon provided 1`
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">
@@ -599,8 +595,6 @@ exports[`order-not-submitted Should return order not submitted when encoded poly
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -629,8 +623,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
@@ -183,8 +183,6 @@ exports[`os-terms Should return os-terms page 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
@@ -179,19 +179,41 @@ exports[`os-terms Should return os-terms page 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
@@ -183,8 +183,6 @@ exports[`terms-and-conditions Should return terms-and-conditions page 1`] = `
 </header>
 
 
-
-
   <section aria-label="Service information" 
 class="govuk-service-navigation"
 data-module="govuk-service-navigation"
@@ -213,8 +211,6 @@ data-module="govuk-service-navigation"
     </div>
 
   </section>
-
-
 
 
 <div class="govuk-phase-banner govuk-width-container">

--- a/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
@@ -226,7 +226,6 @@ data-module="govuk-service-navigation"
 
 
 
-
     
       <div class="govuk-width-container">
         

--- a/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
@@ -179,19 +179,41 @@ exports[`terms-and-conditions Should return terms-and-conditions page 1`] = `
       </a>
     </div>
   
-    <div class="govuk-header__content">
-    
-      
-      <a href="/" class="govuk-header__link govuk-header__service-name">
-        Flood map for planning
-      </a>
-      
-    
-    
-    </div>
-  
   </div>
 </header>
+
+
+
+
+  <section aria-label="Service information" 
+class="govuk-service-navigation"
+data-module="govuk-service-navigation"
+>
+    
+  <div class="govuk-width-container">
+
+    <div class="govuk-service-navigation__container">
+      
+      
+        <span class="govuk-service-navigation__service-name">
+          
+            <a href="/" class="govuk-service-navigation__link">
+              Flood map for planning
+            </a>
+          
+        </span>
+      
+
+      
+      
+      
+      
+    </div>
+
+    </div>
+
+  </section>
+
 
 
 

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -5,6 +5,7 @@
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "button/macro.njk" import govukButton %}
 {% from "back-link/macro.njk" import govukBackLink %}
+{% from "service-navigation/macro.njk" import govukServiceNavigation %}
 
 {% set metaTitle = (pageTitle or model.pageTitle) + ' - Flood map for planning - GOV.UK' %}
 {% set metaDescription = model.metadata.description | default('Get flood risk information and maps for planning applications and planning permission in England, including flood zones and flood risk assessment data.') %}

--- a/server/views/partials/header.html
+++ b/server/views/partials/header.html
@@ -1,9 +1,12 @@
 {{ govukHeader({
   homepageUrl: "https://www.gov.uk/",
   containerClasses: "govuk-width-container",
-  serviceName: serviceName,
-  serviceUrl: "/",
   rebrand: true
+}) }}
+
+{{ govukServiceNavigation({
+  serviceName: serviceName,
+  serviceUrl: "/"
 }) }}
 
 {{ govukPhaseBanner({

--- a/server/views/partials/header.html
+++ b/server/views/partials/header.html
@@ -4,10 +4,10 @@
   rebrand: true
 }) }}
 
-{{ govukServiceNavigation({
+{{- govukServiceNavigation({
   serviceName: serviceName,
   serviceUrl: "/"
-}) }}
+}) -}}
 
 {{ govukPhaseBanner({
   tag: {

--- a/server/views/partials/header.html
+++ b/server/views/partials/header.html
@@ -1,18 +1,18 @@
-{{ govukHeader({
+{{- govukHeader({
   homepageUrl: "https://www.gov.uk/",
   containerClasses: "govuk-width-container",
   rebrand: true
-}) }}
+}) -}}
 
 {{- govukServiceNavigation({
   serviceName: serviceName,
   serviceUrl: "/"
 }) -}}
 
-{{ govukPhaseBanner({
+{{- govukPhaseBanner({
   tag: {
     text: "Beta"
   },
   classes: "govuk-width-container",
   html: 'This is a new service. Help us improve it and <a class="govuk-link" href="/feedback">give your feedback</a>.'
-}) }}
+}) -}}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCRM-6619

Move 'Flood map for planning' in header to section below.