### PR TITLE
Remove white space from views and snapshots

### DIFF
--- a/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
@@ -41,8 +41,6 @@ exports[`accessibility statement Should return accessibility statement page 1`] 
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`accessibility statement Should return accessibility statement page 1`] 
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/accessibility-statement.spec.js.snap
@@ -572,9 +572,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -690,7 +688,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -404,9 +404,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -522,7 +520,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -967,9 +964,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1085,7 +1080,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1530,9 +1524,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1648,7 +1640,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -2093,9 +2084,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -2211,7 +2200,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -2656,9 +2644,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -2774,7 +2760,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -3219,9 +3204,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -3337,7 +3320,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -41,8 +41,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 
@@ -607,8 +604,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -702,7 +697,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 
@@ -1173,8 +1167,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1268,7 +1260,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 
@@ -1739,8 +1730,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1834,7 +1823,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 
@@ -2305,8 +2293,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -2400,7 +2386,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 
@@ -2871,8 +2856,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -2966,7 +2949,6 @@ exports[`Check your details page GET Should serve contact view with error messag
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/check-your-details.spec.js.snap
@@ -241,8 +241,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -264,7 +263,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -801,8 +799,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -824,7 +821,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -1361,8 +1357,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -1384,7 +1379,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -1921,8 +1915,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -1944,7 +1937,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -2481,8 +2473,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -2504,7 +2495,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -3041,8 +3031,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -3064,7 +3053,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">

--- a/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
@@ -309,9 +309,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -427,7 +425,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -777,9 +774,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -895,7 +890,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1248,9 +1242,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1366,7 +1358,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1719,9 +1710,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1837,7 +1826,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/confirmation.spec.js.snap
@@ -41,8 +41,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, enc
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, enc
   </div>
   
 </div>
-
 
 
 
@@ -512,8 +509,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, pol
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -607,7 +602,6 @@ exports[`confirmation Should return content correctly based on flood zone 1, pol
   </div>
   
 </div>
-
 
 
 
@@ -983,8 +977,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, enc
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1078,7 +1070,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, enc
   </div>
   
 </div>
-
 
 
 
@@ -1457,8 +1448,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, pol
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1552,7 +1541,6 @@ exports[`confirmation Should return content correctly based on flood zone 3, pol
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -249,9 +249,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -367,7 +365,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -772,9 +769,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -890,7 +885,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1295,9 +1289,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1413,7 +1405,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1818,9 +1809,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1936,7 +1925,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -2341,9 +2329,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -2459,7 +2445,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -2868,9 +2853,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -2986,7 +2969,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -3395,9 +3377,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -3513,7 +3493,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -3958,9 +3937,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -4076,7 +4053,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -4521,9 +4497,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -4639,7 +4613,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -5084,9 +5057,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -5202,7 +5173,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -5647,9 +5617,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -5765,7 +5733,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -6210,9 +6177,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -6328,7 +6293,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -6773,9 +6737,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -6891,7 +6853,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -41,8 +41,6 @@ exports[`contact GET Should error if no polygon is present 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`contact GET Should error if no polygon is present 1`] = `
   </div>
   
 </div>
-
 
 
 
@@ -452,8 +449,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -547,7 +542,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
   </div>
   
 </div>
-
 
 
 
@@ -978,8 +972,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1073,7 +1065,6 @@ exports[`contact GET Should get contact page if encoded polygon query is present
   </div>
   
 </div>
-
 
 
 
@@ -1504,8 +1495,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1599,7 +1588,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
   </div>
   
 </div>
-
 
 
 
@@ -2030,8 +2018,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -2125,7 +2111,6 @@ exports[`contact GET Should get contact page if polygon query is present, with a
   </div>
   
 </div>
-
 
 
 
@@ -2556,8 +2541,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -2651,7 +2634,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
   </div>
   
 </div>
-
 
 
 
@@ -3086,8 +3068,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -3181,7 +3161,6 @@ exports[`contact GET Should get contact page with user name and email if cookie 
   </div>
   
 </div>
-
 
 
 
@@ -3616,8 +3595,6 @@ exports[`contact POST Should return contact view with error message if blank ema
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -3711,7 +3688,6 @@ exports[`contact POST Should return contact view with error message if blank ema
   </div>
   
 </div>
-
 
 
 
@@ -4182,8 +4158,6 @@ exports[`contact POST Should return contact view with error message if blank nam
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -4277,7 +4251,6 @@ exports[`contact POST Should return contact view with error message if blank nam
   </div>
   
 </div>
-
 
 
 
@@ -4748,8 +4721,6 @@ exports[`contact POST Should return contact view with error message if email con
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -4843,7 +4814,6 @@ exports[`contact POST Should return contact view with error message if email con
   </div>
   
 </div>
-
 
 
 
@@ -5314,8 +5284,6 @@ exports[`contact POST Should return contact view with error message if fullname 
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -5409,7 +5377,6 @@ exports[`contact POST Should return contact view with error message if fullname 
   </div>
   
 </div>
-
 
 
 
@@ -5880,8 +5847,6 @@ exports[`contact POST Should return contact view with error message if invalid e
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -5975,7 +5940,6 @@ exports[`contact POST Should return contact view with error message if invalid e
   </div>
   
 </div>
-
 
 
 
@@ -6446,8 +6410,6 @@ exports[`contact POST Should return contact view with error message if name cont
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -6541,7 +6503,6 @@ exports[`contact POST Should return contact view with error message if name cont
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/contact.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/contact.spec.js.snap
@@ -3774,8 +3774,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -3797,7 +3796,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -4334,8 +4332,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -4357,7 +4354,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -4894,8 +4890,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -4917,7 +4912,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -5454,8 +5448,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -5477,7 +5470,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -6014,8 +6006,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -6037,7 +6028,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">
@@ -6574,8 +6564,7 @@ data-module="govuk-service-navigation"
   <div id="contact-page" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title">
       There is a problem
@@ -6597,7 +6586,6 @@ data-module="govuk-service-navigation"
   </div>
 </div>
 
-        
 
         <h1 class="govuk-heading-xl">Order your flood risk data</h1>
         <p class="govuk-body">

--- a/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
@@ -444,9 +444,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -562,7 +560,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1047,9 +1044,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1165,7 +1160,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1650,9 +1644,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1768,7 +1760,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/cookies.spec.js.snap
@@ -41,8 +41,6 @@ exports[`cookies Should return cookies page successfully with cookies accepted o
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`cookies Should return cookies page successfully with cookies accepted o
   </div>
   
 </div>
-
 
 
 
@@ -647,8 +644,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected b
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -742,7 +737,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected b
   </div>
   
 </div>
-
 
 
 
@@ -1253,8 +1247,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected o
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1348,7 +1340,6 @@ exports[`cookies Should return cookies page successfully with cookies rejected o
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
@@ -41,8 +41,6 @@ exports[`England Only Page england-only with no params 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`England Only Page england-only with no params 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/england-only.spec.js.snap
@@ -266,9 +266,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -384,7 +382,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/error.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/error.spec.js.snap
@@ -249,9 +249,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -367,7 +365,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/error.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/error.spec.js.snap
@@ -41,8 +41,6 @@ exports[`error page Should return error page 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`error page Should return error page 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
@@ -245,9 +245,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -363,7 +361,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -649,9 +646,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -767,7 +762,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1053,9 +1047,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1171,7 +1163,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -1457,9 +1448,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1575,7 +1564,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/feedback.spec.js.snap
@@ -41,8 +41,6 @@ exports[`Feedback Should return feedback page with no userAgent 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`Feedback Should return feedback page with no userAgent 1`] = `
   </div>
   
 </div>
-
 
 
 
@@ -448,8 +445,6 @@ exports[`Feedback Should return feedback page with ref being set as feedback 1`]
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -543,7 +538,6 @@ exports[`Feedback Should return feedback page with ref being set as feedback 1`]
   </div>
   
 </div>
-
 
 
 
@@ -855,8 +849,6 @@ exports[`Feedback Should return feedback page with ref being set without feedbac
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -950,7 +942,6 @@ exports[`Feedback Should return feedback page with ref being set without feedbac
   </div>
   
 </div>
-
 
 
 
@@ -1262,8 +1253,6 @@ exports[`Feedback Should return feedback page with userAgent being set 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -1357,7 +1346,6 @@ exports[`Feedback Should return feedback page with userAgent being set 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/home.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/home.spec.js.snap
@@ -41,8 +41,6 @@ exports[`home route should match snapshot 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`home route should match snapshot 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/home.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/home.spec.js.snap
@@ -369,9 +369,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -487,7 +485,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
@@ -607,9 +607,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -725,7 +723,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/how-to-use-flood-map-for-planning-data.spec.js.snap
@@ -41,8 +41,6 @@ exports[`how-to-use-flood-map-for-planning-data Should return how-to-use-flood-m
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`how-to-use-flood-map-for-planning-data Should return how-to-use-flood-m
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
@@ -41,8 +41,6 @@ exports[`maintenance Should get /maintainence successfully 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`maintenance Should get /maintainence successfully 1`] = `
   </div>
   
 </div>
-
 
 
 
@@ -456,8 +453,6 @@ exports[`maintenance Should get /maintenance successfully 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -551,7 +546,6 @@ exports[`maintenance Should get /maintenance successfully 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/maintenance.spec.js.snap
@@ -253,9 +253,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -371,7 +369,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -665,9 +662,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -783,7 +778,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
@@ -375,9 +375,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -493,7 +491,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/map-help.spec.js.snap
@@ -41,8 +41,6 @@ exports[`map-help Should return map-help page 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`map-help Should return map-help page 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -41,8 +41,6 @@ exports[`next-steps on internal should show the "Order flood risk data" for opte
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`next-steps on internal should show the "Order flood risk data" for opte
   </div>
   
 </div>
-
 
 
 
@@ -613,8 +610,6 @@ exports[`next-steps on public should show the "Order flood risk data" for opted 
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -708,7 +703,6 @@ exports[`next-steps on public should show the "Order flood risk data" for opted 
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/next-steps.spec.js.snap
@@ -407,9 +407,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -525,7 +523,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -981,9 +978,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -1099,7 +1094,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
@@ -41,8 +41,6 @@ exports[`order-not-submitted Should return 400 error when no polgyon provided 1`
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`order-not-submitted Should return 400 error when no polgyon provided 1`
   </div>
   
 </div>
-
 
 
 
@@ -452,8 +449,6 @@ exports[`order-not-submitted Should return order not submitted when encoded poly
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -547,7 +542,6 @@ exports[`order-not-submitted Should return order not submitted when encoded poly
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/order-not-submitted.spec.js.snap
@@ -249,9 +249,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -367,7 +365,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 
@@ -666,9 +663,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -784,7 +779,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
@@ -41,8 +41,6 @@ exports[`os-terms Should return os-terms page 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`os-terms Should return os-terms page 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/os-terms.spec.js.snap
@@ -275,9 +275,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -393,7 +391,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
@@ -41,8 +41,6 @@ exports[`terms-and-conditions Should return terms-and-conditions page 1`] = `
   
 
 
-
-
 <div class="govuk-cookie-banner js-cookies-banner govuk-!-display-none" data-nosnippet role="region" aria-label="Cookies on Flood Map For Planning">
   
   <div class="govuk-cookie-banner__message js-question-banner govuk-width-container" hidden>
@@ -136,7 +134,6 @@ exports[`terms-and-conditions Should return terms-and-conditions page 1`] = `
   </div>
   
 </div>
-
 
 
 

--- a/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
+++ b/server/routes/__tests__/__snapshots__/terms-and-conditions.spec.js.snap
@@ -577,9 +577,7 @@ data-module="govuk-service-navigation"
     
 
     
-  
-
-<footer class="govuk-footer">
+  <footer class="govuk-footer">
   <div class="govuk-width-container">
     
 
@@ -695,7 +693,6 @@ data-module="govuk-service-navigation"
     </div>
   </div>
 </footer>
-
 
 
 

--- a/server/views/check-your-details.html
+++ b/server/views/check-your-details.html
@@ -23,7 +23,7 @@
           You should receive your data within 20 working days.
         </p>
 
-        {{ govukSummaryList({
+        {{- govukSummaryList({
           rows: [{
             key: { text: "Name" },
             value: { text: fullName },
@@ -69,7 +69,7 @@
             value: { text: floodZone }
           }
         ] 
-      }) }}
+      }) -}}
 
       {% if not polygon %}
         {{ govukWarningText({

--- a/server/views/contact.html
+++ b/server/views/contact.html
@@ -12,10 +12,10 @@
     <div class="govuk-grid-column-two-thirds">
 
         {% if errorSummary.length > 0 %}
-          {{ govukErrorSummary({
+          {{- govukErrorSummary({
             titleText: "There is a problem",
             errorList: errorSummary
-          })}}
+          }) -}}
         {% endif %}
 
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
@@ -49,7 +49,7 @@
           errorMessage: findErrorMessageById(errorSummary, "fullName")
         }) }}
 
-        {{ govukInput({
+        {{govukInput({
           label: {
           text: "Email address",
           classes:"govuk-label govuk-label--m"
@@ -61,7 +61,7 @@
           autocomplete: "email",
           errorMessage: findErrorMessageById(errorSummary, "recipientemail"),
           spellcheck: false
-        }) }}
+        })}}
 
         <div id="location-context">
           <input type="hidden" value="{{ polygon }}" name="polygon"/>

--- a/server/views/partials/cookie-banner.html
+++ b/server/views/partials/cookie-banner.html
@@ -6,7 +6,7 @@
   <p class="govuk-body">You've rejected analytics cookies. You can <a href="/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
-{{ govukCookieBanner({
+{{- govukCookieBanner({
   ariaLabel: "Cookies on Flood Map For Planning",    
   classes: "js-cookies-banner govuk-!-display-none",
   messages: [
@@ -55,4 +55,4 @@
       classes: "js-cookies-rejected"
     }
   ]
-}) }}
+}) -}}

--- a/server/views/partials/footer.html
+++ b/server/views/partials/footer.html
@@ -11,7 +11,7 @@
   </p>
 {% endset %}
 
-{{ govukFooter({
+{{- govukFooter({
   rebrand: true,
   meta: {
     items: [
@@ -34,4 +34,4 @@
     ],
     html: html
   }
-}) }}
+}) -}}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCRM-6716

clean the views and test snapshots to remove white space, it makes the tests less messy and the views easier to read.