### PR TITLE
Fcrm 6814 develop map page tests

### DIFF
--- a/e2e/pages/.utils/map-controls.js
+++ b/e2e/pages/.utils/map-controls.js
@@ -1,5 +1,11 @@
+// Left-hand map configuration panel
 export const menuSection = (text) => ({ type: 'menuSection', text })
 export const menuButtonOption = (text) => ({ type: 'menuButtonOption', text })
 export const menuRadioOption = (text) => ({ type: 'menuRadioOption', text })
 export const menuCheckboxOption = (text) => ({ type: 'menuCheckboxOption', text })
+
+// Right-hand map interaction controls
 export const mapButton = (text) => ({ type: 'mapButton', text })
+export const mapLink = (text) => ({ type: 'mapLink', text })
+export const mapMenuButton = (text) => ({ type: 'mapMenuButton', text })
+export const mapMenuOption = (text) => ({ type: 'mapMenuOption', text })

--- a/e2e/pages/map.page.js
+++ b/e2e/pages/map.page.js
@@ -1,4 +1,4 @@
-import { mapButton, menuButtonOption, menuSection } from './.utils/map-controls.js'
+import { mapButton, mapLink, mapMenuButton, mapMenuOption, menuButtonOption, menuCheckboxOption, menuRadioOption, menuSection } from './.utils/map-controls.js'
 import { definePage } from './.utils/page.js'
 
 export const page = definePage({
@@ -6,8 +6,84 @@ export const page = definePage({
   title: 'Interactive map showing flood planning data'
 })
 
+// Controls used to order a P4
 export const locationMenuSection = menuSection('Get data for your location')
+export const addPolygonOption = menuButtonOption('Add polygon')
 export const addSquareOption = menuButtonOption('Add square')
+export const editShapeOption = menuButtonOption('Edit shape')
+export const deleteShapeOption = menuButtonOption('Delete shape')
+
+// Datasets menu options
+export const datasetsMenuSection = menuSection('Datasets')
+export const floodZones2And3Option = menuRadioOption('Flood zones 2 and 3')
+export const surfaceWaterOption = menuRadioOption('Surface water')
+export const noneOption = menuRadioOption('None')
+
+// Climate change menu options
+export const climateMenuSection = menuSection('Climate change')
+export const presentDayOption = menuRadioOption('Present day')
+export const year2070To2125Option = menuRadioOption('2070 to 2125')
+
+// Annual likelihood of flood menu options (shown when Surface water is selected)
+export const annualLikelihoodMenuSection = menuSection('Annual likelihood of flood')
+export const oneIn30Option = menuRadioOption('1 in 30')
+export const oneIn100Option = menuRadioOption('1 in 100')
+export const oneIn1000Option = menuRadioOption('1 in 1000')
+
+// Map features menu options
+export const mapFeaturesMenuSection = menuSection('Map features')
+export const waterStorageOption = menuCheckboxOption('Water storage')
+export const floodDefenceOption = menuCheckboxOption('Flood defence')
+export const mainRiversOption = menuCheckboxOption('Main Rivers')
 
 export const getSummaryReportButton = mapButton('Get summary report')
 export const finishButton = mapButton('Finish')
+
+// Map Interaction Controls
+export const zoomInButton = mapButton('Zoom in')
+export const zoomOutButton = mapButton('Zoom out')
+export const mapHelpLink = mapLink('Help')
+export const mapKeyButton = mapButton('Key')
+
+export const mapSearchButton = mapButton('Search')
+
+// Search input field
+export const mapSearchInput = {
+  type: 'mapSearchInput'
+}
+
+// Dynamic search result (by visible text)
+export const mapSearchResult = (text) => ({
+  type: 'mapSearchResult',
+  text
+})
+
+// Helper to perform a full search + select
+// Note: click() and fill() need to be imported from Playwright page object
+export async function searchAndSelectLocation (page, locationName) {
+  await page.click(mapSearchButton)
+  await page.fill(mapSearchInput, locationName)
+  await page.click(mapSearchResult(locationName))
+}
+
+export const mapStyleMenuButton = mapMenuButton('Choose map style')
+// Map style options
+export const outdoorMapStyleOption = mapMenuOption('Outdoor')
+export const darkMapStyleOption = mapMenuOption('Dark')
+export const blackAndWhiteMapStyleOption = mapMenuOption('Black and white')
+
+// Dismissible banner
+export const bannerCloseButton = mapButton('Close panel')
+
+// Grouped option arrays for use in tests
+export const configSectionMenus = [
+  locationMenuSection,
+  datasetsMenuSection,
+  climateMenuSection,
+  mapFeaturesMenuSection
+]
+export const datasetOptions = [floodZones2And3Option, surfaceWaterOption, noneOption]
+export const annualLikelihoodOptions = [oneIn30Option, oneIn100Option, oneIn1000Option]
+export const climateOptions = [presentDayOption, year2070To2125Option]
+export const mapFeatureOptions = [waterStorageOption, floodDefenceOption, mainRiversOption]
+export const mapStyleOptions = [outdoorMapStyleOption, darkMapStyleOption, blackAndWhiteMapStyleOption]

--- a/e2e/pages/map.page.js
+++ b/e2e/pages/map.page.js
@@ -60,10 +60,10 @@ export const mapSearchResult = (text) => ({
 
 // Helper to perform a full search + select
 // Note: click() and fill() need to be imported from Playwright page object
-export async function searchAndSelectLocation (page, locationName) {
-  await page.click(mapSearchButton)
-  await page.fill(mapSearchInput, locationName)
-  await page.click(mapSearchResult(locationName))
+export async function searchAndSelectLocation (pwPage, locationName) {
+  await pwPage.click(mapSearchButton)
+  await pwPage.fill(mapSearchInput, locationName)
+  await pwPage.click(mapSearchResult(locationName))
 }
 
 export const mapStyleMenuButton = mapMenuButton('Choose map style')
@@ -89,16 +89,16 @@ export const mapFeatureOptions = [waterStorageOption, floodDefenceOption, mainRi
 export const mapStyleOptions = [outdoorMapStyleOption, darkMapStyleOption, blackAndWhiteMapStyleOption]
 
 // Locator helpers for map specs and drivers to avoid duplicated selector definitions.
-export const getMapButton = (page, elementOrText) => {
+export const getMapButton = (pwPage, elementOrText) => {
   const name = typeof elementOrText === 'string' ? elementOrText : elementOrText.text
-  return page.getByRole('button', { name })
+  return pwPage.getByRole('button', { name })
 }
 
-export const getMapSwitch = (page, elementOrText) => {
+export const getMapSwitch = (pwPage, elementOrText) => {
   const name = typeof elementOrText === 'string' ? elementOrText : elementOrText.text
-  return page.getByRole('switch', { name })
+  return pwPage.getByRole('switch', { name })
 }
 
-export const getMapSearchInput = (page) => page.getByRole('combobox')
-export const getMapDialog = (page, name) => page.getByRole('dialog', { name })
-export const getMapViewport = (page) => page.locator('#map-viewport')
+export const getMapSearchInput = (pwPage) => pwPage.getByRole('combobox')
+export const getMapDialog = (pwPage, name) => pwPage.getByRole('dialog', { name })
+export const getMapViewport = (pwPage) => pwPage.locator('#map-viewport')

--- a/e2e/pages/map.page.js
+++ b/e2e/pages/map.page.js
@@ -87,3 +87,18 @@ export const annualLikelihoodOptions = [oneIn30Option, oneIn100Option, oneIn1000
 export const climateOptions = [presentDayOption, year2070To2125Option]
 export const mapFeatureOptions = [waterStorageOption, floodDefenceOption, mainRiversOption]
 export const mapStyleOptions = [outdoorMapStyleOption, darkMapStyleOption, blackAndWhiteMapStyleOption]
+
+// Locator helpers for map specs and drivers to avoid duplicated selector definitions.
+export const getMapButton = (page, elementOrText) => {
+  const name = typeof elementOrText === 'string' ? elementOrText : elementOrText.text
+  return page.getByRole('button', { name })
+}
+
+export const getMapSwitch = (page, elementOrText) => {
+  const name = typeof elementOrText === 'string' ? elementOrText : elementOrText.text
+  return page.getByRole('switch', { name })
+}
+
+export const getMapSearchInput = (page) => page.getByRole('combobox')
+export const getMapDialog = (page, name) => page.getByRole('dialog', { name })
+export const getMapViewport = (page) => page.locator('#map-viewport')

--- a/e2e/test-runner-api/form-driver.js
+++ b/e2e/test-runner-api/form-driver.js
@@ -144,6 +144,9 @@ export class FormDriver {
     if (link.type === 'headerLink') {
       return this.page.locator('header, .govuk-service-navigation, .govuk-phase-banner').getByRole('link', { name: link.text, exact })
     }
+    if (link.type === 'mapLink') {
+      return this.page.getByRole('link', { name: link.text, exact })
+    }
     if (link.type === 'mainLink' || link.type === 'link') {
       return this.page.getByRole('main').getByRole('link', { name: link.text, exact })
     }

--- a/e2e/test-runner-api/map-driver.js
+++ b/e2e/test-runner-api/map-driver.js
@@ -31,11 +31,11 @@ export class MapDriver extends FormDriver {
       return
     }
     if (element.type === 'menuRadioOption') {
-      await this.page.getByRole('radio', { name: element.text, exact: true }).check()
+      await this.page.getByRole('radio', { name: element.text, exact: true }).check({ force: true })
       return
     }
     if (element.type === 'menuCheckboxOption') {
-      await this.page.getByRole('checkbox', { name: element.text, exact: true }).check()
+      await this.page.getByRole('checkbox', { name: element.text, exact: true }).check({ force: true })
       return
     }
     throw new Error(`chooseMenuOption(): unsupported element type '${element.type}'`)

--- a/e2e/tests/pages/map-page.spec.js
+++ b/e2e/tests/pages/map-page.spec.js
@@ -6,11 +6,6 @@ test.describe('Map page', () => {
   const query = 'qzxwvvbnnmm112233445566778899'
   const validQuery = 'Leeds'
 
-  const mapButton = (page, name) => page.getByRole('button', { name, exact: true }).first()
-  const mapSearchInput = (page) => page.getByRole('combobox').first()
-  const mapDialog = (page, name) => page.getByRole('dialog', { name }).first()
-  const mapViewport = (page) => page.locator('#map-viewport').first()
-
   const expectVisibleByRole = async (page, role, options) => {
     for (const option of options) {
       await expect(page.getByRole(role, { name: option.text, exact: true })).toBeVisible()
@@ -19,7 +14,7 @@ test.describe('Map page', () => {
 
   const expectVisibleMenuSections = async (page) => {
     for (const section of pages.map.configSectionMenus) {
-      await expect(page.getByRole('button', { name: new RegExp(section.text, 'i') }).first()).toBeVisible()
+      await expect(page.getByRole('button', { name: new RegExp(section.text, 'i') })).toBeVisible()
     }
   }
 
@@ -27,18 +22,18 @@ test.describe('Map page', () => {
     await container.getByRole('button', { name: closePanelButtonName, exact: true }).click()
   }
 
-  const expectMapLayersUpdate = async (page, options) => {
+  const expectMapLayersUpdate = async (page, mapSteps, options) => {
+    const viewport = pages.map.getMapViewport(page)
     await expectVisibleByRole(page, 'radio', options)
-    await page.getByRole('radio', { name: options[0].text, exact: true }).check({ force: true })
-    await page.waitForTimeout(250)
-    let before = await mapViewport(page).screenshot()
+    await mapSteps.chooseMenuOption(options[0])
+    let before = await viewport.screenshot()
     for (const option of options.slice(1)) {
-      await page.getByRole('radio', { name: option.text, exact: true }).check({ force: true })
+      await mapSteps.chooseMenuOption(option)
       await expect.poll(async () => {
-        const after = await mapViewport(page).screenshot()
+        const after = await viewport.screenshot()
         return Buffer.compare(before, after) !== 0
       }, { timeout: 7000, intervals: [200, 400, 800] }).toBe(true)
-      before = await mapViewport(page).screenshot()
+      before = await viewport.screenshot()
     }
   }
 
@@ -53,8 +48,9 @@ test.describe('Map page', () => {
 
     await mapSteps.expandMenuSection(pages.map.locationMenuSection)
     for (const option of [pages.map.editShapeOption, pages.map.deleteShapeOption]) {
-      await expect(page.getByRole('button', { name: option.text, exact: true })).toBeVisible()
-      await expect(page.getByRole('button', { name: option.text, exact: true })).toBeDisabled()
+      const control = pages.map.getMapButton(page, option)
+      await expect(control).toBeVisible()
+      await expect(control).toBeDisabled()
     }
 
     await expect(page.getByRole('slider', { name: 'Layer opacity' })).toBeVisible()
@@ -65,7 +61,7 @@ test.describe('Map page', () => {
     await mapSteps.expandMenuSection(pages.map.locationMenuSection)
 
     for (const option of [pages.map.addPolygonOption, pages.map.addSquareOption]) {
-      const control = page.getByRole('button', { name: option.text, exact: true })
+      const control = pages.map.getMapButton(page, option)
       await expect(control).toBeVisible()
       await expect(control).toBeEnabled()
     }
@@ -74,37 +70,37 @@ test.describe('Map page', () => {
   // Verifies dataset options are visible and selecting each one updates the rendered map layer.
   test('shows dataset options and updates map layers when selected', async ({ mapSteps, page }) => {
     await mapSteps.expandMenuSection(pages.map.datasetsMenuSection)
-    await expectMapLayersUpdate(page, pages.map.datasetOptions)
+    await expectMapLayersUpdate(page, mapSteps, pages.map.datasetOptions)
   })
 
   test.describe('surface water dataset', () => {
     test.beforeEach(async ({ mapSteps, page }) => {
       await mapSteps.expandMenuSection(pages.map.datasetsMenuSection)
-      await page.getByRole('radio', { name: pages.map.surfaceWaterOption.text, exact: true }).check({ force: true })
+      await mapSteps.chooseMenuOption(pages.map.surfaceWaterOption)
     })
 
     // Verifies selecting Surface water swaps Climate change for Annual likelihood of flood menu, options are visible, and each updates the rendered map layer.
     test('shows annual likelihood options and updates map layers when selected', async ({ mapSteps, page }) => {
-      await expect(page.getByRole('button', { name: /Climate change/i }).first()).toBeHidden()
-      await expect(page.getByRole('button', { name: /Annual likelihood of flood/i }).first()).toBeVisible()
+      await expect(page.getByRole('button', { name: /Climate change/i })).toBeHidden()
+      await expect(page.getByRole('button', { name: /Annual likelihood of flood/i })).toBeVisible()
       await mapSteps.expandMenuSection(pages.map.annualLikelihoodMenuSection)
-      await expectMapLayersUpdate(page, pages.map.annualLikelihoodOptions)
+      await expectMapLayersUpdate(page, mapSteps, pages.map.annualLikelihoodOptions)
     })
   })
 
   // Verifies climate change options are visible and selecting each one updates the rendered map layer.
   test('shows climate change options and updates map layers when selected', async ({ mapSteps, page }) => {
     await mapSteps.expandMenuSection(pages.map.climateMenuSection)
-    await expectMapLayersUpdate(page, pages.map.climateOptions)
+    await expectMapLayersUpdate(page, mapSteps, pages.map.climateOptions)
   })
 
   // Verifies map feature switches are visible, toggle correctly, and update the Key panel.
   test('shows, toggles and reflects map feature switches in key panel', async ({ mapSteps, page }) => {
-    const keyDialog = mapDialog(page, 'Key')
+    const keyDialog = pages.map.getMapDialog(page, 'Key')
     await mapSteps.expandMenuSection(pages.map.mapFeaturesMenuSection)
 
     for (const option of pages.map.mapFeatureOptions) {
-      const toggle = page.getByRole('switch', { name: option.text, exact: true })
+      const toggle = pages.map.getMapSwitch(page, option.text)
       await expect(toggle).toBeVisible()
       await expect(toggle).toHaveAttribute('aria-checked', 'false')
 
@@ -136,37 +132,37 @@ test.describe('Map page', () => {
 
     // Exercises the search button and verifies a search control is shown.
     test('opens map search when clicking search button', async ({ page }) => {
-      await expect(mapSearchInput(page)).toBeVisible()
+      await expect(pages.map.getMapSearchInput(page)).toBeVisible()
     })
 
     // Verifies an invalid query shows a no-results message.
     test('shows error message when searching for an area that does not exist', async ({ page }) => {
-      await mapSearchInput(page).fill(query)
-      await mapSearchInput(page).press('Enter')
-      await expect(mapDialog(page, query)).toContainText('No results are available')
+      await pages.map.getMapSearchInput(page).fill(query)
+      await pages.map.getMapSearchInput(page).press('Enter')
+      await expect(pages.map.getMapDialog(page, query)).toContainText('No results are available')
     })
 
     // Verifies a valid location search shows results and selecting one relocates the map.
     test('shows results when searching for a valid area and relocates map when selecting a result', async ({ page }) => {
       const initialUrl = page.url()
-      const searchInput = mapSearchInput(page)
+      const searchInput = pages.map.getMapSearchInput(page)
 
       await searchInput.fill(validQuery)
       await searchInput.press('Enter')
-      await expect(mapDialog(page, validQuery)).toContainText(/result(s)? (is|are) available/i)
+      await expect(pages.map.getMapDialog(page, validQuery)).toContainText(/result(s)? (is|are) available/i)
 
       await searchInput.press('ArrowDown')
       await searchInput.press('Enter')
       await page.waitForLoadState('networkidle')
       await expect(page).not.toHaveURL(initialUrl)
-      await expect(mapViewport(page)).toBeVisible()
+      await expect(pages.map.getMapViewport(page)).toBeVisible()
     })
   })
 
   test.describe('panel dismiss controls', () => {
     // Verifies the Key panel and map alert banner are present and can each be dismissed.
     test('shows and dismisses key panel and map alert banner', async ({ page }) => {
-      const keyDialog = mapDialog(page, 'Key')
+      const keyDialog = pages.map.getMapDialog(page, 'Key')
       const keyHeading = page.getByRole('heading', { name: 'Key', exact: true })
       const alertStatus = page.getByRole('status').filter({ hasText: 'Click on the flood zones for information' }).first()
 
@@ -183,21 +179,21 @@ test.describe('Map page', () => {
 
   // Verifies zoom controls and map viewport are present.
   test('shows zoom in and zoom out buttons', async ({ page }) => {
-    const zoomInButton = mapButton(page, pages.map.zoomInButton.text)
-    const zoomOutButton = mapButton(page, pages.map.zoomOutButton.text)
+    const zoomInButton = pages.map.getMapButton(page, pages.map.zoomInButton)
+    const zoomOutButton = pages.map.getMapButton(page, pages.map.zoomOutButton)
 
     await expect(zoomInButton).toBeVisible()
     await expect(zoomOutButton).toBeVisible()
-    await expect(mapViewport(page)).toBeVisible()
+    await expect(pages.map.getMapViewport(page)).toBeVisible()
   })
 
   // Verifies style options are available when style menu is opened.
   test('shows map style options when style menu is opened', async ({ page, steps }) => {
-    const styleOption = (label) => mapButton(page, label)
+    const styleOption = (option) => pages.map.getMapButton(page, option)
 
     await steps.clickButton(pages.map.mapStyleMenuButton)
     for (const option of pages.map.mapStyleOptions) {
-      await expect(styleOption(option.text)).toBeVisible()
+      await expect(styleOption(option)).toBeVisible()
     }
   })
 

--- a/e2e/tests/pages/map-page.spec.js
+++ b/e2e/tests/pages/map-page.spec.js
@@ -1,0 +1,210 @@
+import { expect, test } from '../../fixtures.js'
+import { pages } from '../../pages/index.js'
+
+test.describe('Map page', () => {
+  const closePanelButtonName = pages.map.bannerCloseButton.text
+  const query = 'qzxwvvbnnmm112233445566778899'
+  const validQuery = 'Leeds'
+
+  const mapButton = (page, name) => page.getByRole('button', { name, exact: true }).first()
+  const mapSearchInput = (page) => page.getByRole('combobox').first()
+  const mapDialog = (page, name) => page.getByRole('dialog', { name }).first()
+  const mapViewport = (page) => page.locator('#map-viewport').first()
+
+  const expectVisibleByRole = async (page, role, options) => {
+    for (const option of options) {
+      await expect(page.getByRole(role, { name: option.text, exact: true })).toBeVisible()
+    }
+  }
+
+  const expectVisibleMenuSections = async (page) => {
+    for (const section of pages.map.configSectionMenus) {
+      await expect(page.getByRole('button', { name: new RegExp(section.text, 'i') }).first()).toBeVisible()
+    }
+  }
+
+  const dismissPanel = async (container) => {
+    await container.getByRole('button', { name: closePanelButtonName, exact: true }).click()
+  }
+
+  const expectMapLayersUpdate = async (page, options) => {
+    await expectVisibleByRole(page, 'radio', options)
+    await page.getByRole('radio', { name: options[0].text, exact: true }).check({ force: true })
+    await page.waitForTimeout(250)
+    let before = await mapViewport(page).screenshot()
+    for (const option of options.slice(1)) {
+      await page.getByRole('radio', { name: option.text, exact: true }).check({ force: true })
+      await expect.poll(async () => {
+        const after = await mapViewport(page).screenshot()
+        return Buffer.compare(before, after) !== 0
+      }, { timeout: 7000, intervals: [200, 400, 800] }).toBe(true)
+      before = await mapViewport(page).screenshot()
+    }
+  }
+
+  test.beforeEach(async ({ steps }) => {
+    await steps.open(pages.map.page)
+    await steps.expectOn(pages.map.page)
+  })
+
+  // Verifies location controls are visible; Edit/Delete remain disabled until a shape is drawn.
+  test('shows map configuration panel controls', async ({ mapSteps, page }) => {
+    await expectVisibleMenuSections(page)
+
+    await mapSteps.expandMenuSection(pages.map.locationMenuSection)
+    for (const option of [pages.map.editShapeOption, pages.map.deleteShapeOption]) {
+      await expect(page.getByRole('button', { name: option.text, exact: true })).toBeVisible()
+      await expect(page.getByRole('button', { name: option.text, exact: true })).toBeDisabled()
+    }
+
+    await expect(page.getByRole('slider', { name: 'Layer opacity' })).toBeVisible()
+  })
+
+  // Verifies Add Polygon and Add Square controls are visible and enabled.
+  test('shows Add Polygon and Add Square controls as available', async ({ mapSteps, page }) => {
+    await mapSteps.expandMenuSection(pages.map.locationMenuSection)
+
+    for (const option of [pages.map.addPolygonOption, pages.map.addSquareOption]) {
+      const control = page.getByRole('button', { name: option.text, exact: true })
+      await expect(control).toBeVisible()
+      await expect(control).toBeEnabled()
+    }
+  })
+
+  // Verifies dataset options are visible and selecting each one updates the rendered map layer.
+  test('shows dataset options and updates map layers when selected', async ({ mapSteps, page }) => {
+    await mapSteps.expandMenuSection(pages.map.datasetsMenuSection)
+    await expectMapLayersUpdate(page, pages.map.datasetOptions)
+  })
+
+  test.describe('surface water dataset', () => {
+    test.beforeEach(async ({ mapSteps, page }) => {
+      await mapSteps.expandMenuSection(pages.map.datasetsMenuSection)
+      await page.getByRole('radio', { name: pages.map.surfaceWaterOption.text, exact: true }).check({ force: true })
+    })
+
+    // Verifies selecting Surface water swaps Climate change for Annual likelihood of flood menu, options are visible, and each updates the rendered map layer.
+    test('shows annual likelihood options and updates map layers when selected', async ({ mapSteps, page }) => {
+      await expect(page.getByRole('button', { name: /Climate change/i }).first()).toBeHidden()
+      await expect(page.getByRole('button', { name: /Annual likelihood of flood/i }).first()).toBeVisible()
+      await mapSteps.expandMenuSection(pages.map.annualLikelihoodMenuSection)
+      await expectMapLayersUpdate(page, pages.map.annualLikelihoodOptions)
+    })
+  })
+
+  // Verifies climate change options are visible and selecting each one updates the rendered map layer.
+  test('shows climate change options and updates map layers when selected', async ({ mapSteps, page }) => {
+    await mapSteps.expandMenuSection(pages.map.climateMenuSection)
+    await expectMapLayersUpdate(page, pages.map.climateOptions)
+  })
+
+  // Verifies map feature switches are visible, toggle correctly, and update the Key panel.
+  test('shows, toggles and reflects map feature switches in key panel', async ({ mapSteps, page }) => {
+    const keyDialog = mapDialog(page, 'Key')
+    await mapSteps.expandMenuSection(pages.map.mapFeaturesMenuSection)
+
+    for (const option of pages.map.mapFeatureOptions) {
+      const toggle = page.getByRole('switch', { name: option.text, exact: true })
+      await expect(toggle).toBeVisible()
+      await expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+      const keyBefore = await keyDialog.screenshot()
+      await toggle.click()
+      await expect(toggle).toHaveAttribute('aria-checked', 'true')
+      expect(Buffer.compare(keyBefore, await keyDialog.screenshot())).not.toBe(0)
+
+      await toggle.click()
+      await expect(toggle).toHaveAttribute('aria-checked', 'false')
+    }
+  })
+
+  // Verifies the layer opacity slider UI is present with expected accessibility attributes.
+  test('layer opacity slider is present', async ({ page }) => {
+    const slider = page.getByRole('slider', { name: 'Layer opacity' })
+
+    await expect(page.getByRole('group', { name: 'Layer opacity' })).toBeVisible()
+    await expect(slider).toBeVisible()
+    await expect(slider).toHaveAttribute('aria-valuemin', '0')
+    await expect(slider).toHaveAttribute('aria-valuemax', '100')
+    await expect(slider).toHaveAttribute('aria-valuenow', /\d+/)
+  })
+
+  test.describe('map search', () => {
+    test.beforeEach(async ({ steps }) => {
+      await steps.clickButton(pages.map.mapSearchButton)
+    })
+
+    // Exercises the search button and verifies a search control is shown.
+    test('opens map search when clicking search button', async ({ page }) => {
+      await expect(mapSearchInput(page)).toBeVisible()
+    })
+
+    // Verifies an invalid query shows a no-results message.
+    test('shows error message when searching for an area that does not exist', async ({ page }) => {
+      await mapSearchInput(page).fill(query)
+      await mapSearchInput(page).press('Enter')
+      await expect(mapDialog(page, query)).toContainText('No results are available')
+    })
+
+    // Verifies a valid location search shows results and selecting one relocates the map.
+    test('shows results when searching for a valid area and relocates map when selecting a result', async ({ page }) => {
+      const initialUrl = page.url()
+      const searchInput = mapSearchInput(page)
+
+      await searchInput.fill(validQuery)
+      await searchInput.press('Enter')
+      await expect(mapDialog(page, validQuery)).toContainText(/result(s)? (is|are) available/i)
+
+      await searchInput.press('ArrowDown')
+      await searchInput.press('Enter')
+      await page.waitForLoadState('networkidle')
+      await expect(page).not.toHaveURL(initialUrl)
+      await expect(mapViewport(page)).toBeVisible()
+    })
+  })
+
+  test.describe('panel dismiss controls', () => {
+    // Verifies the Key panel and map alert banner are present and can each be dismissed.
+    test('shows and dismisses key panel and map alert banner', async ({ page }) => {
+      const keyDialog = mapDialog(page, 'Key')
+      const keyHeading = page.getByRole('heading', { name: 'Key', exact: true })
+      const alertStatus = page.getByRole('status').filter({ hasText: 'Click on the flood zones for information' }).first()
+
+      await expect(keyHeading).toBeVisible()
+      await expect(alertStatus).toBeVisible()
+
+      await dismissPanel(keyDialog)
+      await expect(keyHeading).toBeHidden()
+
+      await dismissPanel(alertStatus.locator('..'))
+      await expect(alertStatus).toBeHidden()
+    })
+  })
+
+  // Verifies zoom controls and map viewport are present.
+  test('shows zoom in and zoom out buttons', async ({ page }) => {
+    const zoomInButton = mapButton(page, pages.map.zoomInButton.text)
+    const zoomOutButton = mapButton(page, pages.map.zoomOutButton.text)
+
+    await expect(zoomInButton).toBeVisible()
+    await expect(zoomOutButton).toBeVisible()
+    await expect(mapViewport(page)).toBeVisible()
+  })
+
+  // Verifies style options are available when style menu is opened.
+  test('shows map style options when style menu is opened', async ({ page, steps }) => {
+    const styleOption = (label) => mapButton(page, label)
+
+    await steps.clickButton(pages.map.mapStyleMenuButton)
+    for (const option of pages.map.mapStyleOptions) {
+      await expect(styleOption(option.text)).toBeVisible()
+    }
+  })
+
+  // Confirms the Help link opens the map-help page in a new tab.
+  test('navigates to map help page when clicking the map help link', async ({ steps }) => {
+    await steps.clickLink(pages.map.mapHelpLink)
+    await steps.switchToNewWindow()
+    await steps.expectOn(pages.mapHelp.page)
+  })
+})


### PR DESCRIPTION
Adds test coverage for the map page (controls, datasets/layers, features, search, panel dismissals, styles, zoom, and help navigation) through updating the framework and adding a spec file.

These are mainly UI validation tests with a few functional flows. I did look into things like actually drawing polygons and manipulating the data layer opacity slider, but was struggling to get them to work. So perhaps something to be progressed later.