### PR TITLE
FCRM-6870-E2E-Changed approach for flaky map tests. Added additional results scenario

### DIFF
--- a/e2e/data/location-data.js
+++ b/e2e/data/location-data.js
@@ -79,6 +79,9 @@ export const floodZonedata = {
   // Polygon 300.01 hectares in size for Flood zone 3 with rivers and surface water flooding
   polygon300_01: '[[569264.26,235805.29],[570996.34,235805.29],[570996.34,234073.21],[569264.26,234073.21],[569264.26,235805.29]]',
 
+  // Polygon over 300 hectares in size in an opted-out area
+  polygonOver300InOptedOutArea: '[[525573.01,197020.56],[527321.52,197020.56],[527321.52,195272.04],[525573.01,195272.04],[525573.01,197020.56]]',
+
   // Polygon which is not under an area teams jurisdiction Flood zone 3
   area_Team_NoJurisdiction: '[[497260.09,423202.36], [497737.82,423202.36], [497737.82,422724.63], [497260.09,422724.63], [497260.09,423202.36]]',
 

--- a/e2e/tests/pages/map-page.spec.js
+++ b/e2e/tests/pages/map-page.spec.js
@@ -22,19 +22,35 @@ test.describe('Map page', () => {
     await container.getByRole('button', { name: closePanelButtonName, exact: true }).click()
   }
 
-  const expectMapLayersUpdate = async (page, mapSteps, options, { expectKeyPanelUpdate = true } = {}) => {
-    const viewport = pages.map.getMapViewport(page)
+  const expectMapLayersUpdate = async (
+    page,
+    mapSteps,
+    sectionLabel,
+    options,
+    { expectKeyPanelUpdate = true } = {}
+  ) => {
     const keyDialog = pages.map.getMapDialog(page, 'Key')
+
+    const expectMenuSummaryToMatchSelection = async (option) => {
+      const summaryButton = page.getByRole('button', {
+        name: new RegExp(`${sectionLabel}.*${option.text}`, 'i')
+      })
+      await expect(summaryButton).toContainText(option.text)
+    }
+
     await expectVisibleByRole(page, 'radio', options)
     await mapSteps.chooseMenuOption(options[0])
-    let before = await viewport.screenshot()
+    await expect(page.getByRole('radio', { name: options[0].text, exact: true })).toBeChecked()
+    await expectMenuSummaryToMatchSelection(options[0])
     let keyBefore = expectKeyPanelUpdate ? await keyDialog.screenshot() : null
+
     for (const option of options.slice(1)) {
       await mapSteps.chooseMenuOption(option)
-      await expect.poll(async () => {
-        const after = await viewport.screenshot()
-        return Buffer.compare(before, after) !== 0
-      }, { timeout: 7000, intervals: [200, 400, 800] }).toBe(true)
+
+      // In prod, map tile pixels can remain unchanged for equivalent-looking layers.
+      // Assert deterministic selected-state and menu-summary updates instead.
+      await expect(page.getByRole('radio', { name: option.text, exact: true })).toBeChecked()
+      await expectMenuSummaryToMatchSelection(option)
 
       if (expectKeyPanelUpdate) {
         await expect.poll(async () => {
@@ -43,7 +59,6 @@ test.describe('Map page', () => {
         }, { timeout: 7000, intervals: [200, 400, 800] }).toBe(true)
       }
 
-      before = await viewport.screenshot()
       if (expectKeyPanelUpdate) {
         keyBefore = await keyDialog.screenshot()
       }
@@ -80,10 +95,10 @@ test.describe('Map page', () => {
     }
   })
 
-  // Verifies dataset options are visible and selecting each one updates the rendered map layer and Key panel.
+  // Verifies dataset options are visible and selecting each one updates selected state, section summary, and Key panel.
   test('shows dataset options and updates map layers when selected', async ({ mapSteps, page }) => {
     await mapSteps.expandMenuSection(pages.map.datasetsMenuSection)
-    await expectMapLayersUpdate(page, mapSteps, pages.map.datasetOptions)
+    await expectMapLayersUpdate(page, mapSteps, pages.map.datasetsMenuSection.text, pages.map.datasetOptions)
   })
 
   test.describe('surface water dataset', () => {
@@ -92,27 +107,44 @@ test.describe('Map page', () => {
       await mapSteps.chooseMenuOption(pages.map.surfaceWaterOption)
     })
 
-    // Verifies Surface water menus are visible, options are visible, each updates the rendered map layer, and depth options also update the Key panel.
+    // Verifies Surface water menus are visible, options are visible, each updates selected state and section summary, and depth options also update the Key panel.
     test('shows surface water menu options and updates map layers when selected', async ({ mapSteps, page }) => {
       await expect(page.getByRole('button', { name: /Climate change/i })).toBeVisible()
       await expect(page.getByRole('button', { name: /Annual likelihood of flood/i })).toBeVisible()
       await expect(page.getByRole('button', { name: /Depth in millimetres/i })).toBeVisible()
 
       await mapSteps.expandMenuSection(pages.map.climateMenuSectionSW)
-      await expectMapLayersUpdate(page, mapSteps, pages.map.climateOptionsSW, { expectKeyPanelUpdate: false })
+      await expectMapLayersUpdate(
+        page,
+        mapSteps,
+        pages.map.climateMenuSectionSW.text,
+        pages.map.climateOptionsSW,
+        { expectKeyPanelUpdate: false }
+      )
 
       await mapSteps.expandMenuSection(pages.map.annualLikelihoodMenuSection)
-      await expectMapLayersUpdate(page, mapSteps, pages.map.annualLikelihoodOptions, { expectKeyPanelUpdate: false })
+      await expectMapLayersUpdate(
+        page,
+        mapSteps,
+        pages.map.annualLikelihoodMenuSection.text,
+        pages.map.annualLikelihoodOptions,
+        { expectKeyPanelUpdate: false }
+      )
 
       await mapSteps.expandMenuSection(pages.map.surfaceWaterDepthMenuSection)
-      await expectMapLayersUpdate(page, mapSteps, pages.map.surfaceWaterDepthOptions)
+      await expectMapLayersUpdate(
+        page,
+        mapSteps,
+        pages.map.surfaceWaterDepthMenuSection.text,
+        pages.map.surfaceWaterDepthOptions
+      )
     })
   })
 
-  // Verifies climate change options are visible and selecting each one updates the rendered map layer and Key panel.
+  // Verifies climate change options are visible and selecting each one updates selected state, section summary, and Key panel.
   test('shows climate change options and updates map layers when selected', async ({ mapSteps, page }) => {
     await mapSteps.expandMenuSection(pages.map.climateMenuSection)
-    await expectMapLayersUpdate(page, mapSteps, pages.map.climateOptions)
+    await expectMapLayersUpdate(page, mapSteps, pages.map.climateMenuSection.text, pages.map.climateOptions)
   })
 
   // Verifies map feature switches are visible, toggle correctly, and update the Key panel.

--- a/e2e/tests/pages/results-page-conditional-content.spec.js
+++ b/e2e/tests/pages/results-page-conditional-content.spec.js
@@ -97,6 +97,12 @@ test.describe('Results page - Order flood risk data availability', () => {
     await steps.expectLinkNotExists(pages.results.orderFloodRiskDataButton)
   })
 
+  test('does not show order flood risk data or edit boundary links when in an opted-out area over 300 hectares', async ({ steps }) => {
+    await steps.open(pages.results.pageForPolygon('3', floodZonedata.polygonOver300InOptedOutArea))
+    await steps.expectLinkNotExists(pages.results.orderFloodRiskDataButton)
+    await steps.expectLinkNotExists(pages.results.editBoundaryLink)
+  })
+
   test('shows order flood risk data link when in an opted-out area using internal URL', { tag: '@internal' }, async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('1', areaData.HertfordshireAndNorthLondon.polygon))
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)


### PR DESCRIPTION
1 or 2 of the map tests were a bit flaky. Updated so it stops checking if map pixels changed, it instead checks that the right option is selected and the UI updates correctly. It should still check the Key panel visuals in the same places.

The map tests will have to be revised later based on the Jenkins stuff I think anyway, so will await your thoughts on that when you are able to get to it.

Also, after saying yesterday that I thought that was it for results page, I thought of one more while looking at the release today. So have added that!