### PR TITLE
FCRM-6973-E2E-Updated risk profiles section and tests

### DIFF
--- a/e2e/pages/results.page.js
+++ b/e2e/pages/results.page.js
@@ -70,6 +70,7 @@ export const sw1in30PdText =
 // Risk profiles
 export const riskIntro = 'In your proposed development site there is a risk of flooding from:'
 const surfaceWaterRisk = 'surface water'
+export const riskProfilesSection = '[data-testid="risk-profiles"]' // Selector for the risk profiles section
 export const riskProfiles = {
   surfaceWater: [riskIntro, surfaceWaterRisk],
   fluvialAndSurfaceWater: [riskIntro, 'rivers (fluvial)', surfaceWaterRisk],

--- a/e2e/pages/results.page.js
+++ b/e2e/pages/results.page.js
@@ -83,3 +83,29 @@ export const riskProfiles = {
   climateChangeAndSurfaceWater: [riskIntro, 'rivers and the sea (fluvial or tidal) due to climate change', surfaceWaterRisk]
 }
 export const allRiskLines = [...new Set(Object.values(riskProfiles).flat().filter((line) => line !== riskIntro))]
+
+// Risk profile assertion
+export const expectRiskProfileTexts = async (page, expectedTexts, allTexts) => {
+  const { expect } = await import('@playwright/test')
+  const main = page.getByRole('main')
+  const [introText, ...expectedRiskItems] = expectedTexts
+
+  const riskIntroLocator = main.getByText(introText, { exact: true }).first()
+  await expect(riskIntroLocator).toBeVisible()
+
+  // Risk lines are shown in the first list within the same content block as the intro text.
+  const riskList = riskIntroLocator.locator('..').getByRole('list').first()
+
+  await expect(riskList).toBeVisible()
+
+  for (const text of expectedRiskItems) {
+    await expect(riskList.getByText(text, { exact: true })).toBeVisible()
+  }
+
+  const allRiskItems = allTexts.filter((text) => text !== introText)
+  for (const text of allRiskItems) {
+    if (!expectedRiskItems.includes(text)) {
+      await expect(riskList.getByText(text, { exact: true })).toHaveCount(0)
+    }
+  }
+}

--- a/e2e/pages/results.page.js
+++ b/e2e/pages/results.page.js
@@ -70,42 +70,16 @@ export const sw1in30PdText =
 // Risk profiles
 export const riskIntro = 'In your proposed development site there is a risk of flooding from:'
 const surfaceWaterRisk = 'surface water'
-export const riskProfilesSection = '[data-testid="risk-profiles"]' // Selector for the risk profiles section
 export const riskProfiles = {
-  surfaceWater: [riskIntro, surfaceWaterRisk],
-  fluvialAndSurfaceWater: [riskIntro, 'rivers (fluvial)', surfaceWaterRisk],
-  tidalAndSurfaceWater: [riskIntro, 'the sea (tidal)', surfaceWaterRisk],
-  fluvialTidalAndSurfaceWater: [riskIntro, 'rivers and the sea (fluvial and tidal)', surfaceWaterRisk],
-  fluvialAndTidal: [riskIntro, 'rivers and the sea (fluvial and tidal)'],
-  fluvial: [riskIntro, 'rivers (fluvial)'],
-  tidal: [riskIntro, 'the sea (tidal)'],
-  climateChange: [riskIntro, 'rivers and the sea (fluvial or tidal) due to climate change'],
-  climateChangeAndSurfaceWater: [riskIntro, 'rivers and the sea (fluvial or tidal) due to climate change', surfaceWaterRisk]
+  surfaceWater: [surfaceWaterRisk],
+  fluvialAndSurfaceWater: ['rivers (fluvial)', surfaceWaterRisk],
+  tidalAndSurfaceWater: ['the sea (tidal)', surfaceWaterRisk],
+  fluvialTidalAndSurfaceWater: ['rivers and the sea (fluvial and tidal)', surfaceWaterRisk],
+  fluvialAndTidal: ['rivers and the sea (fluvial and tidal)'],
+  fluvial: ['rivers (fluvial)'],
+  tidal: ['the sea (tidal)'],
+  climateChange: ['rivers and the sea (fluvial or tidal) due to climate change'],
+  climateChangeAndSurfaceWater: ['rivers and the sea (fluvial or tidal) due to climate change', surfaceWaterRisk]
 }
-export const allRiskLines = [...new Set(Object.values(riskProfiles).flat().filter((line) => line !== riskIntro))]
-
-// Risk profile assertion
-export const expectRiskProfileTexts = async (page, expectedTexts, allTexts) => {
-  const { expect } = await import('@playwright/test')
-  const main = page.getByRole('main')
-  const [introText, ...expectedRiskItems] = expectedTexts
-
-  const riskIntroLocator = main.getByText(introText, { exact: true }).first()
-  await expect(riskIntroLocator).toBeVisible()
-
-  // Risk lines are shown in the first list within the same content block as the intro text.
-  const riskList = riskIntroLocator.locator('..').getByRole('list').first()
-
-  await expect(riskList).toBeVisible()
-
-  for (const text of expectedRiskItems) {
-    await expect(riskList.getByText(text, { exact: true })).toBeVisible()
-  }
-
-  const allRiskItems = allTexts.filter((text) => text !== introText)
-  for (const text of allRiskItems) {
-    if (!expectedRiskItems.includes(text)) {
-      await expect(riskList.getByText(text, { exact: true })).toHaveCount(0)
-    }
-  }
-}
+export const allRiskLines = [...new Set(Object.values(riskProfiles).flat())]
+export const riskProfilesSection = '#riskFloodingFrom + ul' // locator for risk profiles list, used to scope text assertions

--- a/e2e/test-runner-api/form-driver.js
+++ b/e2e/test-runner-api/form-driver.js
@@ -91,20 +91,20 @@ export class FormDriver {
     await expect(this.page.getByRole('heading', { name: pageDef.title, exact: true })).toBeVisible()
   }
 
-  async expectText (text) {
-    await expect(this.page.getByRole('main')).toContainText(text)
+  async expectText (text, scope) {
+    await expect(this.#getTextScope(scope)).toContainText(text)
   }
 
-  async expectTextNotExists (text) {
-    await expect(this.page.getByRole('main')).not.toContainText(text)
+  async expectTextNotExists (text, scope) {
+    await expect(this.#getTextScope(scope)).not.toContainText(text)
   }
 
-  async expectOnlyTexts (expectedTexts, allTexts) {
+  async expectOnlyTexts (expectedTexts, allTexts, scope) {
     for (const text of allTexts) {
       if (expectedTexts.includes(text)) {
-        await this.expectText(text)
+        await this.expectText(text, scope)
       } else {
-        await this.expectTextNotExists(text)
+        await this.expectTextNotExists(text, scope)
       }
     }
   }
@@ -165,5 +165,18 @@ export class FormDriver {
       return this.page.getByRole('main').getByRole('link', { name: link.text, exact })
     }
     throw new Error(`Unsupported link type '${link.type}'`)
+  }
+
+  #getTextScope (scope) {
+    if (!scope) {
+      return this.page.getByRole('main')
+    }
+    if (typeof scope === 'string') {
+      return this.page.locator(scope)
+    }
+    if (typeof scope === 'object' && typeof scope.locator === 'function') {
+      return scope
+    }
+    throw new Error(`Unsupported text scope '${String(scope)}'`)
   }
 }

--- a/e2e/test-runner-api/form-driver.js
+++ b/e2e/test-runner-api/form-driver.js
@@ -109,6 +109,30 @@ export class FormDriver {
     }
   }
 
+  async expectRiskProfileTexts (expectedTexts, allTexts) {
+    const main = this.page.getByRole('main')
+    const [introText, ...expectedRiskItems] = expectedTexts
+
+    const riskIntro = main.getByText(introText, { exact: true }).first()
+    await expect(riskIntro).toBeVisible()
+
+    // Risk lines are shown in the first list within the same content block as the intro text.
+    const riskList = riskIntro.locator('..').getByRole('list').first()
+
+    await expect(riskList).toBeVisible()
+
+    for (const text of expectedRiskItems) {
+      await expect(riskList.getByText(text, { exact: true })).toBeVisible()
+    }
+
+    const allRiskItems = allTexts.filter((text) => text !== introText)
+    for (const text of allRiskItems) {
+      if (!expectedRiskItems.includes(text)) {
+        await expect(riskList.getByText(text, { exact: true })).toHaveCount(0)
+      }
+    }
+  }
+
   async expectErrorText (element) {
     await expect(this.page.getByRole('alert')).toBeVisible()
     await expect(this.page.getByRole('alert')).toContainText(element.text)

--- a/e2e/test-runner-api/form-driver.js
+++ b/e2e/test-runner-api/form-driver.js
@@ -109,30 +109,6 @@ export class FormDriver {
     }
   }
 
-  async expectRiskProfileTexts (expectedTexts, allTexts) {
-    const main = this.page.getByRole('main')
-    const [introText, ...expectedRiskItems] = expectedTexts
-
-    const riskIntro = main.getByText(introText, { exact: true }).first()
-    await expect(riskIntro).toBeVisible()
-
-    // Risk lines are shown in the first list within the same content block as the intro text.
-    const riskList = riskIntro.locator('..').getByRole('list').first()
-
-    await expect(riskList).toBeVisible()
-
-    for (const text of expectedRiskItems) {
-      await expect(riskList.getByText(text, { exact: true })).toBeVisible()
-    }
-
-    const allRiskItems = allTexts.filter((text) => text !== introText)
-    for (const text of allRiskItems) {
-      if (!expectedRiskItems.includes(text)) {
-        await expect(riskList.getByText(text, { exact: true })).toHaveCount(0)
-      }
-    }
-  }
-
   async expectErrorText (element) {
     await expect(this.page.getByRole('alert')).toBeVisible()
     await expect(this.page.getByRole('alert')).toContainText(element.text)

--- a/e2e/tests/pages/results-page-conditional-content.spec.js
+++ b/e2e/tests/pages/results-page-conditional-content.spec.js
@@ -56,21 +56,24 @@ test.describe('Results page - Flood zone 2 and 3 content', () => {
     await steps.open(pages.results.pageForPolygon('2', floodZonedata.FZ2_With_SW_and_S_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines)
+    await steps.expectText(pages.results.riskIntro)
+    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines, pages.results.riskProfilesSection)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial and surface water', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_SW_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines)
+    await steps.expectText(pages.results.riskIntro)
+    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines, pages.results.riskProfilesSection)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial only', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvial, pages.results.allRiskLines)
+    await steps.expectText(pages.results.riskIntro)
+    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvial, pages.results.allRiskLines, pages.results.riskProfilesSection)
   })
 })
 

--- a/e2e/tests/pages/results-page-conditional-content.spec.js
+++ b/e2e/tests/pages/results-page-conditional-content.spec.js
@@ -56,21 +56,21 @@ test.describe('Results page - Flood zone 2 and 3 content', () => {
     await steps.open(pages.results.pageForPolygon('2', floodZonedata.FZ2_With_SW_and_S_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines)
+    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial and surface water', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_SW_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines)
+    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial only', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectOnlyTexts(pages.results.riskProfiles.fluvial, pages.results.allRiskLines)
+    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvial, pages.results.allRiskLines)
   })
 })
 

--- a/e2e/tests/pages/results-page-conditional-content.spec.js
+++ b/e2e/tests/pages/results-page-conditional-content.spec.js
@@ -56,21 +56,21 @@ test.describe('Results page - Flood zone 2 and 3 content', () => {
     await steps.open(pages.results.pageForPolygon('2', floodZonedata.FZ2_With_SW_and_S_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines)
+    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvialTidalAndSurfaceWater, pages.results.allRiskLines)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial and surface water', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_SW_and_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines)
+    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvialAndSurfaceWater, pages.results.allRiskLines)
   })
 
   test('shows FRA required messaging and order flood risk data link in Flood Zone 3 with fluvial only', async ({ steps }) => {
     await steps.open(pages.results.pageForPolygon('3', floodZonedata.FZ3_With_R))
     await steps.expectText(pages.results.fraRequiredText)
     await steps.expectLinkExists(pages.results.orderFloodRiskDataButton)
-    await steps.expectRiskProfileTexts(pages.results.riskProfiles.fluvial, pages.results.allRiskLines)
+    await pages.results.expectRiskProfileTexts(steps.page, pages.results.riskProfiles.fluvial, pages.results.allRiskLines)
   })
 })
 


### PR DESCRIPTION
As per Teams - Right so the issue was the risk type in the app was not showing surface water when it should have been.
 
This wasn't being picked up as the test was checking the whole page so had found 'surface water' text elsewhere on the page.
 
It is now focussed on the correct area. I have run in tst where it fails (Issue still present) and when I run in pre it works (Issue fixed) so seems ok.
 